### PR TITLE
Fixed typo for sws_flags for filtering

### DIFF
--- a/doc/ffmpeg-scaler.texi
+++ b/doc/ffmpeg-scaler.texi
@@ -53,7 +53,7 @@ Select nearest neighbor rescaling algorithm.
 @item area
 Select averaging area rescaling algorithm.
 
-@item bicubiclin
+@item bicublin
 Select bicubic scaling algorithm for the luma component, bilinear for
 chroma components.
 


### PR DESCRIPTION
Bicubiclin should be bicublin.

The typo tripped me up during debugging.
