### PR TITLE
Compiles tools/ismindex.c under Windows/MinGW

### DIFF
--- a/tools/ismindex.c
+++ b/tools/ismindex.c
@@ -40,6 +40,8 @@
 #define mkdir(a, b) _mkdir(a)
 #endif
 
+#include "cmdutils.h"
+
 #include "libavformat/avformat.h"
 #include "libavutil/intreadwrite.h"
 #include "libavutil/mathematics.h"


### PR DESCRIPTION
Include cmdutils.h so we can build under windows. 

Based on fix for https://ffmpeg.org/trac/ffmpeg/ticket/256
