### PR TITLE
When wav chunk size is not word aligned, assume the next chunk does start on a word boundary

### DIFF
--- a/libavformat/wavdec.c
+++ b/libavformat/wavdec.c
@@ -66,15 +66,16 @@ static int64_t next_tag(AVIOContext *pb, uint32_t *tag)
 static int64_t find_tag(AVIOContext *pb, uint32_t tag1)
 {
     unsigned int tag;
-    int64_t size;
+    int64_t size, offset;
 
     for (;;) {
         if (url_feof(pb))
             return -1;
-        size = next_tag(pb, &tag);
+        size = offset = next_tag(pb, &tag);
         if (tag == tag1)
             break;
-        avio_skip(pb, size);
+        if(offset % 2) offset++;
+        avio_skip(pb, offset);
     }
     return size;
 }
@@ -269,6 +270,7 @@ static int wav_read_header(AVFormatContext *s)
         AVStream *vst;
         size = next_tag(pb, &tag);
         next_tag_ofs = avio_tell(pb) + size;
+        if(next_tag_ofs % 2) next_tag_ofs++;
 
         if (url_feof(pb))
             break;


### PR DESCRIPTION
Some software (Sonic Studio for example) generates bext chunks with an odd length while starting the next chunk on an even offset.

Loads of other wav reading implementations (sox, os x, windows) take this into account.
