### PR TITLE
configure: allow the gas-preprocessor to be called with an absolute path...

### DIFF
--- a/configure
+++ b/configure
@@ -1595,6 +1595,7 @@ CMDLINE_SET="
     cxx
     dep_cc
     extra_version
+    gas
     host_cc
     host_cflags
     host_ld
@@ -3318,7 +3319,7 @@ case $target_os in
         strip="strip -d"
         ;;
     darwin)
-        gas="gas-preprocessor.pl $cc"
+        test "${as#*gas-preprocessor.pl}" != "$as" || gas="${gas:=gas-preprocessor.pl} ${as:=$cc}"
         enabled ppc && add_asflags -force_cpusubtype_ALL
         SHFLAGS='-dynamiclib -Wl,-single_module -Wl,-install_name,$(SHLIBDIR)/$(SLIBNAME_WITH_MAJOR),-current_version,$(LIBVERSION),-compatibility_version,$(LIBMAJOR)'
         enabled x86_32 && append SHFLAGS -Wl,-read_only_relocs,suppress


### PR DESCRIPTION
....

Allow the configure tool to call the gas-preprocessor with an absolute
path when included with either the "--as" or with a separate "--gas"
option.  The patch is backward compatible and will not break any current
configuration setups.

The new behavior that comes with this option can be utilized in the
following ways:

Examples:
- Just as single option that includes both the gas-preprocessor.pl and
  cc/as at the same time:
  
  $ configure --as="/opt/app/build-tools/gas-preprocessor.pl \
                   /Applications/Xcode.app/.../Developer/usr/bin/gcc"
- Call gas-preprocessor with a separate option in conjunction with --as:
  
  $ configure --gas="/opt/app/build-tools/gas-preprocessor.pl" \
               --as="/Applications/Xcode.app/.../Developer/usr/bin/gcc"
- Address only the the gas-preprocessor and it will automatically fall
  back to as or cc whichever that's defined:
  $ configure --gas="/opt/app/build-tools/gas-preprocessor.pl"
- Or if no gas-preprocessor.pl is explicitly defined, it falls back to
  the old behaivor.
