### PR TITLE
h264: do not discard NAL_SEI when skipping frames

### DIFF
--- a/libavcodec/h264.c
+++ b/libavcodec/h264.c
@@ -4757,8 +4757,7 @@ static int decode_nal_units(H264Context *h, const uint8_t *buf, int buf_size,
                     first_slice = hx->nal_unit_type;
                 }
 
-            // FIXME do not discard SEI id
-            if (avctx->skip_frame >= AVDISCARD_NONREF && h->nal_ref_idc == 0)
+            if (avctx->skip_frame >= AVDISCARD_NONREF && h->nal_ref_idc == 0 && h->nal_unit_type != NAL_SEI)
                 continue;
 
 again:


### PR DESCRIPTION
setting AVDISCARD_NONREF e.g. after flushing resulted in 100% dropped frames. 
