### PR TITLE
print_segments: Print segment filenames when they are complete and written to disk.

### DIFF
--- a/doc/muxers.texi
+++ b/doc/muxers.texi
@@ -779,6 +779,10 @@ muxers/codecs. It is set to @code{0} by default.
 @item initial_offset @var{offset}
 Specify timestamp offset to apply to the output packet timestamps. The
 argument must be a time duration specification, and defaults to 0.
+
+@item print_segments @var{1|0}
+Print segment filenames to AV_INFO_LOG when it is complete and written
+to disk. 
 @end table
 
 @subsection Examples


### PR DESCRIPTION
Have added the option to print the filenames of the segments that are created when they are complete and written to disk.

This was a need for me to do a call to action when each segment is complete without the need to wait for the entire file to be segmented. 
