### PR TITLE
Fix a bug

### DIFF
--- a/libavformat/rtpproto.c
+++ b/libavformat/rtpproto.c
@@ -281,6 +281,7 @@ static int rtp_open(URLContext *h, const char *uri, int flags)
     char buf[1024];
     char path[1024];
     const char *p;
+	int i, max_retry_count = 3;
 
     av_url_split(NULL, 0, NULL, 0, hostname, sizeof(hostname), &rtp_port,
                  path, sizeof(path), uri);
@@ -328,20 +329,35 @@ static int rtp_open(URLContext *h, const char *uri, int flags)
         }
     }
 
-    build_udp_url(buf, sizeof(buf),
-                  hostname, rtp_port, local_rtp_port, ttl, max_packet_size,
-                  connect, include_sources, exclude_sources);
-    if (ffurl_open(&s->rtp_hd, buf, flags, &h->interrupt_callback, NULL) < 0)
-        goto fail;
-    local_rtp_port = ff_udp_get_local_port(s->rtp_hd);
-    if (local_rtp_port>=0 && local_rtp_port < 65535 && local_rtcp_port<0)
-        local_rtcp_port = local_rtp_port + 1;
-
-    build_udp_url(buf, sizeof(buf),
-                  hostname, rtcp_port, local_rtcp_port, ttl, max_packet_size,
-                  connect, include_sources, exclude_sources);
-    if (ffurl_open(&s->rtcp_hd, buf, flags, &h->interrupt_callback, NULL) < 0)
-        goto fail;
+	for (i = 0;i < max_retry_count;i++) {
+    	build_udp_url(buf, sizeof(buf),
+    	              hostname, rtp_port, local_rtp_port, ttl, max_packet_size,
+    	              connect, include_sources, exclude_sources);
+    	if (ffurl_open(&s->rtp_hd, buf, flags, &h->interrupt_callback, NULL) < 0)
+    	    goto fail;
+    	local_rtp_port = ff_udp_get_local_port(s->rtp_hd);
+		if(local_rtp_port == 65535) {
+			local_rtp_port = -1;
+			continue;
+		}
+    	if (local_rtcp_port<0) {
+    	    local_rtcp_port = local_rtp_port + 1;
+    		build_udp_url(buf, sizeof(buf),
+    		              hostname, rtcp_port, local_rtcp_port, ttl, max_packet_size,
+    		              connect, include_sources, exclude_sources);
+    		if (ffurl_open(&s->rtcp_hd, buf, flags, &h->interrupt_callback, NULL) < 0) {
+				local_rtp_port = local_rtcp_port = -1;
+				continue;
+			}
+			break;
+		}
+    	build_udp_url(buf, sizeof(buf),
+    				  hostname, rtcp_port, local_rtcp_port, ttl, max_packet_size,
+    				  connect, include_sources, exclude_sources);
+    	if (ffurl_open(&s->rtcp_hd, buf, flags, &h->interrupt_callback, NULL) < 0) 
+			goto fail;
+		break;
+	}
 
     /* just to ease handle access. XXX: need to suppress direct handle
        access */


### PR DESCRIPTION
Update value of variable local_rtp_port before checking if it is not less than zero

This bug makes the rtcp port and rtp port are not two successive integers which are sent to client as server ports.

But some video players on Android will not send udp hole punching messages if the rtcp port and rtp port are not two successive integers.So, if the video player is behind NAT, it cannot receive any rtp messages via udp.
