### PR TITLE
Fix a bug:When a client is behind NAT, it cannot receive any packets sent from ffserver via udp.

### DIFF
--- a/libavformat/avio.c
+++ b/libavformat/avio.c
@@ -187,6 +187,14 @@ static int url_alloc_for_protocol (URLContext **puc, struct URLProtocol *up,
     return err;
 }
 
+/* Update udp client port */
+int ff_update_client_port(URLContext *h) {
+	int err = -1;
+	if(h && h->prot && h->prot->update_client_port)
+		err = h->prot->update_client_port(h);
+	return err;
+}
+
 int ffurl_connect(URLContext* uc, AVDictionary **options)
 {
     int err =

--- a/libavformat/rtpproto.c
+++ b/libavformat/rtpproto.c
@@ -281,11 +281,7 @@ static int rtp_open(URLContext *h, const char *uri, int flags)
     char buf[1024];
     char path[1024];
     const char *p;
-<<<<<<< HEAD
-	int i, max_retry_count = 3;
-=======
     int i, max_retry_count = 3;
->>>>>>> upstream/master
 
     av_url_split(NULL, 0, NULL, 0, hostname, sizeof(hostname), &rtp_port,
                  path, sizeof(path), uri);
@@ -511,6 +507,21 @@ static int rtp_close(URLContext *h)
     return 0;
 }
 
+static int rtp_update_client_port(URLContext *h) 
+{
+	RTPContext *s = h->priv_data;
+	URLContext *rtp_hd = s->rtp_hd;
+	URLContext *rtcp_hd = s->rtcp_hd;
+	int err0 = -1, err1 = -1;
+	if(rtp_hd && rtp_hd->prot && rtp_hd->prot->update_client_port) {
+		err0 = rtp_hd->prot->update_client_port(rtp_hd);
+	}
+	if(rtcp_hd && rtcp_hd->prot && rtcp_hd->prot->update_client_port) {
+		err1 = rtcp_hd->prot->update_client_port(rtcp_hd);
+	}
+	return err0 + err1;
+}
+
 /**
  * Return the local rtp port used by the RTP connection
  * @param h media file context
@@ -564,4 +575,5 @@ URLProtocol ff_rtp_protocol = {
     .url_get_multi_file_handle = rtp_get_multi_file_handle,
     .priv_data_size            = sizeof(RTPContext),
     .flags                     = URL_PROTOCOL_FLAG_NETWORK,
+	.update_client_port        = rtp_update_client_port,
 };

--- a/libavformat/url.h
+++ b/libavformat/url.h
@@ -89,6 +89,7 @@ typedef struct URLProtocol {
     const AVClass *priv_data_class;
     int flags;
     int (*url_check)(URLContext *h, int mask);
+	int (*update_client_port)(URLContext *h);
 } URLProtocol;
 
 /**
@@ -247,6 +248,8 @@ URLProtocol *ffurl_protocol_next(URLProtocol *prev);
 /* udp.c */
 int ff_udp_set_remote_url(URLContext *h, const char *uri);
 int ff_udp_get_local_port(URLContext *h);
+
+int ff_update_client_port(URLContext *h);
 
 /**
  * Assemble a URL string from components. This is the reverse operation


### PR DESCRIPTION
When ffserver sends rtp packets via udp, the udp ports of client is got from header of SETUP request.But if the client is behind NAT, the client ports got from header of SETUP request are not ones mapped by NAT but client's private ports. In this case, the client can't get any packets because ffserver still sends that to client's private ports.

In fact, clients(such as vlc, video player on android) send two udp packets to ffserver for punching a hole on NAT after  getting reply of SETUP request. So, we should receive the two udp packets, retrieve real client ports mapped by NAT, and send packets to the client via the real ports.
