### PR TITLE
vda_h264_dec: backup callbacks before overriding

### DIFF
--- a/libavcodec/vda_h264_dec.c
+++ b/libavcodec/vda_h264_dec.c
@@ -56,6 +56,14 @@ typedef struct {
     int h264_initialized;
     struct vda_context vda_ctx;
     enum AVPixelFormat pix_fmt;
+
+    /* for backing-up callbacks set by user.
+     * we have to gain the full control of the buffer here */
+    enum AVPixelFormat (*get_format)(struct AVCodecContext *s, const enum AVPixelFormat * fmt);
+    int (*get_buffer2)(struct AVCodecContext *s, AVFrame *frame, int flags);
+#if FF_API_GET_BUFFER
+    int (*get_buffer)(struct AVCodecContext *c, AVFrame *pic);
+#endif
 } VDADecoderContext;
 
 static enum AVPixelFormat get_format(struct AVCodecContext *avctx,
@@ -90,6 +98,29 @@ static int get_buffer2(AVCodecContext *avctx, AVFrame *pic, int flag)
     return 0;
 }
 
+static inline void set_callbacks(AVCodecContext *avctx)
+{
+    VDADecoderContext *ctx = avctx->priv_data;
+    ctx->get_format = avctx->get_format;
+    avctx->get_format = get_format;
+    ctx->get_buffer2 = avctx->get_buffer2;
+    avctx->get_buffer2 = get_buffer2;
+#if FF_API_GET_BUFFER
+    ctx->get_buffer = avctx->get_buffer;
+    avctx->get_buffer = NULL;
+#endif
+}
+
+static inline void restore_callbacks(AVCodecContext *avctx)
+{
+    VDADecoderContext *ctx = avctx->priv_data;
+    avctx->get_format = ctx->get_format;
+    avctx->get_buffer2 = ctx->get_buffer2;
+#if FF_API_GET_BUFFER
+    avctx->get_buffer = ctx->get_buffer;
+#endif
+}
+
 static int vdadec_decode(AVCodecContext *avctx,
         void *data, int *got_frame, AVPacket *avpkt)
 {
@@ -97,7 +128,9 @@ static int vdadec_decode(AVCodecContext *avctx,
     AVFrame *pic = data;
     int ret;
 
+    set_callbacks(avctx);
     ret = ff_h264_decoder.decode(avctx, data, got_frame, avpkt);
+    restore_callbacks(avctx);
     if (*got_frame) {
         AVBufferRef *buffer = pic->buf[0];
         VDABufferContext *context = av_buffer_get_opaque(buffer);
@@ -130,8 +163,11 @@ static av_cold int vdadec_close(AVCodecContext *avctx)
     /* release buffers and decoder */
     ff_vda_destroy_decoder(&ctx->vda_ctx);
     /* close H.264 decoder */
-    if (ctx->h264_initialized)
+    if (ctx->h264_initialized) {
+        set_callbacks(avctx);
         ff_h264_decoder.close(avctx);
+        restore_callbacks(avctx);
+    }
     return 0;
 }
 
@@ -186,16 +222,10 @@ static av_cold int vdadec_init(AVCodecContext *avctx)
     }
     avctx->hwaccel_context = vda_ctx;
 
-    /* changes callback functions */
-    avctx->get_format = get_format;
-    avctx->get_buffer2 = get_buffer2;
-#if FF_API_GET_BUFFER
-    // force the old get_buffer to be empty
-    avctx->get_buffer = NULL;
-#endif
-
     /* init H.264 decoder */
+    set_callbacks(avctx);
     ret = ff_h264_decoder.init(avctx);
+    restore_callbacks(avctx);
     if (ret < 0) {
         av_log(avctx, AV_LOG_ERROR, "Failed to open H.264 decoder.\n");
         goto failed;
@@ -211,7 +241,9 @@ failed:
 
 static void vdadec_flush(AVCodecContext *avctx)
 {
-    return ff_h264_decoder.flush(avctx);
+    set_callbacks(avctx);
+    ff_h264_decoder.flush(avctx);
+    restore_callbacks(avctx);
 }
 
 AVCodec ff_h264_vda_decoder = {


### PR DESCRIPTION
avcodec.h says the callbacks could be set by user, but we have to gain the full control of such callbacks in this wrapper decoder, so we save and restore them before and after invoking the inner decoder.
