### PR TITLE
hls: Support for seeking on event playlists (backport)

### DIFF
--- a/libavformat/hls.c
+++ b/libavformat/hls.c
@@ -81,12 +81,14 @@ struct variant {
     int stream_offset;
 
     int finished;
+    int event;
     int target_duration;
     int start_seq_no;
     int n_segments;
     struct segment **segments;
     int needed, cur_needed;
     int cur_seq_no;
+    int first_seq_no;
     int64_t last_load_time;
 
     char key_url[MAX_URL_SIZE];
@@ -241,6 +243,7 @@ static int parse_playlist(HLSContext *c, const char *url,
     if (var) {
         free_segment_list(var);
         var->finished = 0;
+        var->event = 0;
     }
     while (!url_feof(in)) {
         read_chomp_line(in, line, sizeof(line));
@@ -281,6 +284,16 @@ static int parse_playlist(HLSContext *c, const char *url,
                 }
             }
             var->start_seq_no = atoi(ptr);
+        } else if (av_strstart(line, "#EXT-X-PLAYLIST-TYPE:", &ptr)) {
+            if (!var) {
+                var = new_variant(c, 0, url, NULL);
+                if (!var) {
+                    ret = AVERROR(ENOMEM);
+                    goto fail;
+                }
+            }
+            if (!strcmp(ptr, "EVENT"))
+                var->event = 1;
         } else if (av_strstart(line, "#EXT-X-ENDLIST", &ptr)) {
             if (var)
                 var->finished = 1;
@@ -552,6 +565,7 @@ static int hls_read_header(AVFormatContext *s)
         v->cur_seq_no = v->start_seq_no;
         if (!v->finished && v->n_segments > 3)
             v->cur_seq_no = v->start_seq_no + v->n_segments - 3;
+        v->first_seq_no = v->cur_seq_no;
 
         v->read_buffer = av_malloc(INITIAL_BUFFER_SIZE);
         ffio_init_context(&v->pb, v->read_buffer, INITIAL_BUFFER_SIZE, 0, v,
@@ -747,8 +761,10 @@ static int hls_read_seek(AVFormatContext *s, int stream_index,
 {
     HLSContext *c = s->priv_data;
     int i, j, ret;
+    int64_t first_timestamp, seek_timestamp, duration;
 
-    if ((flags & AVSEEK_FLAG_BYTE) || !c->variants[0]->finished)
+    if ((flags & AVSEEK_FLAG_BYTE) ||
+        !(c->variants[0]->finished || c->variants[0]->event))
         return AVERROR(ENOSYS);
 
     c->seek_flags     = flags;
@@ -757,11 +773,20 @@ static int hls_read_seek(AVFormatContext *s, int stream_index,
                                        s->streams[stream_index]->time_base.den,
                                        flags & AVSEEK_FLAG_BACKWARD ?
                                        AV_ROUND_DOWN : AV_ROUND_UP);
-    timestamp = av_rescale_rnd(timestamp, 1, stream_index >= 0 ?
-                               s->streams[stream_index]->time_base.den :
-                               AV_TIME_BASE, flags & AVSEEK_FLAG_BACKWARD ?
-                               AV_ROUND_DOWN : AV_ROUND_UP);
-    if (s->duration < c->seek_timestamp) {
+		first_timestamp = c->first_timestamp == AV_NOPTS_VALUE ? 0 :
+                      av_rescale_rnd(c->first_timestamp, 1, stream_index >= 0 ?
+                      							 s->streams[stream_index]->time_base.den : AV_TIME_BASE,
+			                               flags & AVSEEK_FLAG_BACKWARD ?
+			                               AV_ROUND_DOWN : AV_ROUND_UP);
+    seek_timestamp = av_rescale_rnd(timestamp, 1, stream_index >= 0 ?
+			                               s->streams[stream_index]->time_base.den : AV_TIME_BASE,
+			                               flags & AVSEEK_FLAG_BACKWARD ?
+			                               AV_ROUND_DOWN : AV_ROUND_UP);
+    duration = s->duration == AV_NOPTS_VALUE ?
+               0 : s->duration / AV_TIME_BASE;
+
+    if (seek_timestamp < first_timestamp ||
+        (duration && duration < seek_timestamp - first_timestamp)) {
         c->seek_timestamp = AV_NOPTS_VALUE;
         return AVERROR(EIO);
     }
@@ -770,12 +795,8 @@ static int hls_read_seek(AVFormatContext *s, int stream_index,
     for (i = 0; i < c->n_variants; i++) {
         /* Reset reading */
         struct variant *var = c->variants[i];
-        int64_t pos = c->first_timestamp == AV_NOPTS_VALUE ? 0 :
-                      av_rescale_rnd(c->first_timestamp, 1, stream_index >= 0 ?
-                               s->streams[stream_index]->time_base.den :
-                               AV_TIME_BASE, flags & AVSEEK_FLAG_BACKWARD ?
-                               AV_ROUND_DOWN : AV_ROUND_UP);
-         if (var->input) {
+        int64_t pos = first_timestamp;
+        if (var->input) {
             ffurl_close(var->input);
             var->input = NULL;
         }
@@ -788,9 +809,9 @@ static int hls_read_seek(AVFormatContext *s, int stream_index,
         var->pb.pos = 0;
 
         /* Locate the segment that contains the target timestamp */
-        for (j = 0; j < var->n_segments; j++) {
-            if (timestamp >= pos &&
-                timestamp < pos + var->segments[j]->duration) {
+        for (j = var->first_seq_no - var->start_seq_no; j < var->n_segments; j++) {
+            if (seek_timestamp >= pos &&
+                seek_timestamp < pos + var->segments[j]->duration) {
                 var->cur_seq_no = var->start_seq_no + j;
                 ret = 0;
                 break;


### PR DESCRIPTION
This allows clients to seek between first played segment
and the last one in the live stream playlist with
# EXT-X-PLAYLIST-TYPE:EVENT attribute.

Backported from #50
