### PR TITLE
fixes seeking on huge HLS archive video

### DIFF
--- a/libavformat/hls.c
+++ b/libavformat/hls.c
@@ -859,6 +859,11 @@ static int hls_read_seek(AVFormatContext *s, int stream_index,
     if ((flags & AVSEEK_FLAG_BYTE) || !c->variants[0]->playlists[0]->finished)
         return AVERROR(ENOSYS);
 
+    if (s->duration < timestamp) {
+        c->seek_timestamp = AV_NOPTS_VALUE;
+        return AVERROR(EIO);
+    }
+
     c->seek_flags     = flags;
     c->seek_timestamp = stream_index < 0 ? timestamp :
                         av_rescale_rnd(timestamp, AV_TIME_BASE,


### PR DESCRIPTION
I noticed that current ffmpeg HLS implementation was not able to make seek on video archive with long duration (3 hours & higher). Without this fix, when timestamp higher 3 hours c->seek_timestamp becomes negative and seek will never ends.
