### PR TITLE
Fix get_cookies when it comes across the Expires directive

### DIFF
--- a/libavformat/http.c
+++ b/libavformat/http.c
@@ -484,8 +484,10 @@ static int get_cookies(HTTPContext *s, char **cookies, const char *path,
         char *param, *next_param, *cdomain = NULL, *cpath = NULL, *cvalue = NULL;
         set_cookies = NULL;
 
-        while ((param = av_strtok(cookie, "; ", &next_param))) {
+        while ((param = av_strtok(cookie, ";", &next_param))) {
             cookie = NULL;
+            /* skip leading spaces */
+            param += strspn(param, " ");
             if        (!av_strncasecmp("path=",   param, 5)) {
                 av_free(cpath);
                 cpath = av_strdup(&param[5]);
@@ -498,8 +500,9 @@ static int get_cookies(HTTPContext *s, char **cookies, const char *path,
             } else if (!av_strncasecmp("secure",  param, 6) ||
                        !av_strncasecmp("comment", param, 7) ||
                        !av_strncasecmp("max-age", param, 7) ||
-                       !av_strncasecmp("version", param, 7)) {
-                // ignore Comment, Max-Age, Secure and Version
+                       !av_strncasecmp("version", param, 7) ||
+                       !av_strncasecmp("expires", param, 7)) {
+                // ignore Comment, Max-Age, Secure, Version and Expires
             } else {
                 av_free(cvalue);
                 cvalue = av_strdup(param);


### PR DESCRIPTION
Some cookies that come back from an HLS stream have an Expires directive.
This gets parsed incorrectly by the `get_cookies` method. This fixes the
parsing and ignores the Expires directive altogether.

A little more info:

A cookie with the Expires directive gets parsed incorrectly such that each space in the Expires directive becomes it's own param like so:

A cookie like this `lu=Rg3vHJZnehYLjVg7qi3bZjzg; Expires=Tue, 15-Jan-2013 21:47:38 GMT; Path=/; Domain=.example.com;` will get tokened: 
- `lu=Rg3vHJZnehYLjVg7qi3bZjzg`
- `Expires=Tue,`
- `15-Jan-2013`
- `21:47:38`
- `GMT`

such that each of those is considered its own param in the while loop.
