### PR TITLE
fix dvd stillframes read thru libdvdnav ended up in internal lavf buffer

### DIFF
--- a/libavformat/utils.c
+++ b/libavformat/utils.c
@@ -659,7 +659,7 @@ no_packet:
 
         if (end || av_log2(pd->buf_size) != av_log2(pd->buf_size - pkt->size)) {
             int score = set_codec_from_probe_data(s, st, pd);
-            if (    (st->codec->codec_id != AV_CODEC_ID_NONE && score > AVPROBE_SCORE_RETRY)
+            if (    (st->codec->codec_id != AV_CODEC_ID_NONE && score > AVPROBE_SCORE_RETRY-1)
                 || end) {
                 pd->buf_size = 0;
                 av_freep(&pd->buf);


### PR DESCRIPTION
This is the solution we've been using in XBMC for over 2 years for dvd still frames. The problem is that the demuxer asks for probing of the codec in the mpeg stream. This causes lavf to read the whole menu structure into internal buffers. After which, it won't read from input stream anymore and no events triggers.

Goal is to integrate this back upstream. See
https://github.com/xbmc/xbmc/commit/d2e4acfd41735cf68d23e7777c50eade37b3abd9
https://github.com/xbmc/xbmc/commit/45e41b9096869062a2113590f3158321d06dea8b
