### PR TITLE
fixed: remuxing failed by example code

### DIFF
--- a/doc/examples/remuxing.c
+++ b/doc/examples/remuxing.c
@@ -99,6 +99,7 @@ int main(int argc, char **argv)
             fprintf(stderr, "Failed to copy context from input to output stream codec context\n");
             goto end;
         }
+        out_stream->codec->codec_tag = 0;
         if (ofmt_ctx->oformat->flags & AVFMT_GLOBALHEADER)
             out_stream->codec->flags |= CODEC_FLAG_GLOBAL_HEADER;
     }


### PR DESCRIPTION
I got an error while remuxing a mp4 file while using the example code. After I set codec_tag = 0, it works fine.
I didn't get further in it, maybe there should be a better solution.
Please fix it.
