### PR TITLE
configure: Fix ld flags when rpath is enabled.

### DIFF
--- a/configure
+++ b/configure
@@ -4822,7 +4822,7 @@ check_disable_warning -Wno-pointer-sign
 # add some linker flags
 check_ldflags -Wl,--warn-common
 check_ldflags -Wl,-rpath-link=libpostproc:libswresample:libswscale:libavfilter:libavdevice:libavformat:libavcodec:libavutil:libavresample
-enabled rpath && add_ldflags -Wl,-rpath=$libdir
+enabled rpath && add_ldflags -Wl,-rpath,$libdir
 test_ldflags -Wl,-Bsymbolic && append SHFLAGS -Wl,-Bsymbolic
 
 # add some strip flags


### PR DESCRIPTION
Provide correct rpath flags to ld when --enable-rpath is provided.
