### PR TITLE
FIX: [h264_mp4toannexb] issue when sps/pps are already in the bistream

### DIFF
--- a/libavcodec/h264_mp4toannexb_bsf.c
+++ b/libavcodec/h264_mp4toannexb_bsf.c
@@ -28,6 +28,7 @@
 typedef struct H264BSFContext {
     uint8_t  length_size;
     uint8_t  first_idr;
+    uint8_t  idr_sps_pps_seen;
     int      extradata_parsed;
 } H264BSFContext;
 
@@ -155,6 +156,7 @@ static int h264_mp4toannexb_filter(AVBitStreamFilterContext *bsfc,
             return ret;
         ctx->length_size      = ret;
         ctx->first_idr        = 1;
+        ctx->idr_sps_pps_seen = 0;
         ctx->extradata_parsed = 1;
     }
 
@@ -174,8 +176,12 @@ static int h264_mp4toannexb_filter(AVBitStreamFilterContext *bsfc,
         if (buf + nal_size > buf_end || nal_size < 0)
             goto fail;
 
-        /* prepend only to the first type 5 NAL unit of an IDR picture */
-        if (ctx->first_idr && (unit_type == 5 || unit_type == 7 || unit_type == 8)) {
+        if (ctx->first_idr && (unit_type == 7 || unit_type == 8))
+            ctx->idr_sps_pps_seen = 1;
+
+
+        /* prepend only to the first type 5 NAL unit of an IDR picture, if no sps/pps are already present */
+        if (ctx->first_idr && unit_type == 5 && !ctx->idr_sps_pps_seen) {
             if ((ret=alloc_and_copy(poutbuf, poutbuf_size,
                                avctx->extradata, avctx->extradata_size,
                                buf, nal_size)) < 0)
@@ -185,8 +191,10 @@ static int h264_mp4toannexb_filter(AVBitStreamFilterContext *bsfc,
             if ((ret=alloc_and_copy(poutbuf, poutbuf_size,
                                NULL, 0, buf, nal_size)) < 0)
                 goto fail;
-            if (!ctx->first_idr && unit_type == 1)
+            if (!ctx->first_idr && unit_type == 1) {
                 ctx->first_idr = 1;
+                ctx->idr_sps_pps_seen = 0;
+            }
         }
 
         buf        += nal_size;


### PR DESCRIPTION
This fix an issue in AnnexB conversion where "hiccups" are to be seen if sps/pps are already in the stream.

It's a follow-up to http://ffmpeg.org/pipermail/ffmpeg-devel/2014-March/155911.html , which solved most of the issues but not all.
See https://github.com/xbmc/xbmc/pull/5042 for the XBMC discussion.

My best guess for now is that https://github.com/FFmpeg/FFmpeg/commit/289b149cecb381522cc9ccdf382825330169c655#diff-0e332ff3db7b093bfee7dda7ed82ce19 is flawed if non-idr pics have sps/pps of their own. Then ffmpeg adds extradata to non-idr pics, too. 

If the stream already has sps/pps of their own, I don't think there is an added value to re-add those from extradata, so this patch just don't prepend if they're already present. 

Sample: http://www.semperpax.be/owncloud/public.php?service=files&t=a28e4f3e2305ba08837c45f42c4a3662
