### PR TITLE
Support broken v4l2 webcams

### DIFF
--- a/libavdevice/v4l2.c
+++ b/libavdevice/v4l2.c
@@ -488,7 +488,7 @@ static int convert_timestamp(AVFormatContext *ctx, int64_t *ts)
     return 0;
 }
 
-static int mmap_read_frame(AVFormatContext *ctx, AVPacket *pkt)
+static int mmap_read_frame(AVFormatContext *ctx, AVPacket *pkt, int retry)
 {
     struct video_data *s = ctx->priv_data;
     struct v4l2_buffer buf = {
@@ -524,11 +524,14 @@ static int mmap_read_frame(AVFormatContext *ctx, AVPacket *pkt)
         s->frame_size = buf.bytesused;
 
     if (s->frame_size > 0 && buf.bytesused != s->frame_size) {
-        av_log(ctx, AV_LOG_ERROR,
-               "The v4l2 frame is %d bytes, but %d bytes are expected\n",
-               buf.bytesused, s->frame_size);
         enqueue_buffer(s, &buf);
-        return AVERROR_INVALIDDATA;
+        if(retry > 3) {
+            av_log(ctx, AV_LOG_ERROR,
+                   "The v4l2 frame is %d bytes, but %d bytes are expected\n",
+                   buf.bytesused, s->frame_size);
+            return AVERROR_INVALIDDATA;
+        }
+        return mmap_read_frame(ctx, pkt, retry+1);
     }
 
     /* Image is at s->buff_start[buf.index] */
@@ -967,7 +970,7 @@ static int v4l2_read_packet(AVFormatContext *ctx, AVPacket *pkt)
     int res;
 
     av_init_packet(pkt);
-    if ((res = mmap_read_frame(ctx, pkt)) < 0) {
+    if ((res = mmap_read_frame(ctx, pkt, 0)) < 0) {
         return res;
     }
 


### PR DESCRIPTION
This fixes "The v4l2 frame is %d bytes, but %d bytes are expected" when using a cheap webcam with v4l2.

It will try 3 times before failing instead of failing right away.

Example (src = `Cubeternet GL-UPC822 UVC WebCam`, dst = `v4l2loopback max_width=320 max_height=240`):

    ffmpeg -re -s 640x480 -f v4l2 -i /dev/video0 -f v4l2 -s 320x240 -r 15 -pix_fmt yuv420p /dev/video1
    ...........
    [video4linux2,v4l2 @ 0x1ad8060] The v4l2 frame is 1628 bytes, but 614400 bytes are expected

then exits.