### PR TITLE
Abort inactive rtsp client connection after timeout

### DIFF
--- a/libavformat/rtsp.c
+++ b/libavformat/rtsp.c
@@ -50,11 +50,8 @@
 #include "rtpenc.h"
 #include "mpegts.h"
 
-/* Timeout values for socket poll, in ms,
- * and read_packet(), in seconds  */
+/* Timeout values for socket poll, in ms */
 #define POLL_TIMEOUT_MS 100
-#define READ_PACKET_TIMEOUT_S 10
-#define MAX_TIMEOUTS READ_PACKET_TIMEOUT_S * 1000 / POLL_TIMEOUT_MS
 #define SDP_MAX_SIZE 16384
 #define RECVBUF_SIZE 10 * RTP_MAX_PACKET_LENGTH
 #define DEFAULT_REORDERING_DELAY 100000
@@ -90,7 +87,7 @@ const AVOption ff_rtsp_options[] = {
     RTSP_MEDIATYPE_OPTS("allowed_media_types", "set media types to accept from the server"),
     { "min_port", "set minimum local UDP port", OFFSET(rtp_port_min), AV_OPT_TYPE_INT, {.i64 = RTSP_RTP_PORT_MIN}, 0, 65535, DEC|ENC },
     { "max_port", "set maximum local UDP port", OFFSET(rtp_port_max), AV_OPT_TYPE_INT, {.i64 = RTSP_RTP_PORT_MAX}, 0, 65535, DEC|ENC },
-    { "timeout", "set maximum timeout (in seconds) to wait for incoming connections (-1 is infinite, imply flag listen)", OFFSET(initial_timeout), AV_OPT_TYPE_INT, {.i64 = -1}, INT_MIN, INT_MAX, DEC },
+    { "timeout", "set maximum timeout (in seconds) to wait for incoming connections (-1 is infinite), or to abort an inactive connection to a server (by default 10 seconds)", OFFSET(initial_timeout), AV_OPT_TYPE_INT, {.i64 = -1}, INT_MIN, INT_MAX, DEC },
     { "stimeout", "set timeout (in microseconds) of socket TCP I/O operations", OFFSET(stimeout), AV_OPT_TYPE_INT, {.i64 = 0}, INT_MIN, INT_MAX, DEC },
     RTSP_REORDERING_OPTS(),
     { "user-agent", "override User-Agent header", OFFSET(user_agent), AV_OPT_TYPE_STRING, {.str = LIBAVFORMAT_IDENT}, 0, 0, DEC },
@@ -1833,6 +1830,7 @@ static int udp_read_packet(AVFormatContext *s, RTSPStream **prtsp_st,
     RTSPState *rt = s->priv_data;
     RTSPStream *rtsp_st;
     int n, i, ret, tcp_fd, timeout_cnt = 0;
+    int max_timeouts = rt->initial_timeout * 1000 / POLL_TIMEOUT_MS;
     int max_p = 0;
     struct pollfd *p = rt->p;
     int *fds = NULL, fdsnum, fdsidx;
@@ -1871,6 +1869,11 @@ static int udp_read_packet(AVFormatContext *s, RTSPStream **prtsp_st,
             }
         }
         n = poll(p, max_p, POLL_TIMEOUT_MS);
+        if (n == 0) {
+            av_log(s, AV_LOG_DEBUG,
+                   "udp poll timeout occurred (%d of max %d)\n",
+                   timeout_cnt, max_timeouts);
+        }
         if (n > 0) {
             int j = 1 - (tcp_fd == -1);
             timeout_cnt = 0;
@@ -1909,7 +1912,7 @@ static int udp_read_packet(AVFormatContext *s, RTSPStream **prtsp_st,
                 }
             }
 #endif
-        } else if (n == 0 && ++timeout_cnt >= MAX_TIMEOUTS) {
+        } else if (n == 0 && ++timeout_cnt >= max_timeouts) {
             return AVERROR(ETIMEDOUT);
         } else if (n < 0 && errno != EINTR)
             return AVERROR(errno);

--- a/libavformat/rtsp.h
+++ b/libavformat/rtsp.h
@@ -77,6 +77,9 @@ enum RTSPControlTransport {
 #define RTSP_RTP_PORT_MIN 5000
 #define RTSP_RTP_PORT_MAX 65000
 
+/* Default timeout values for read_packet(), in seconds. */
+#define RTSP_DEFAULT_READ_PACKET_TIMEOUT_S 10
+
 /**
  * This describes a single item in the "Transport:" line of one stream as
  * negotiated by the SETUP RTSP command. Multiple transports are comma-

--- a/libavformat/rtspdec.c
+++ b/libavformat/rtspdec.c
@@ -683,14 +683,14 @@ static int rtsp_read_header(AVFormatContext *s)
     RTSPState *rt = s->priv_data;
     int ret;
 
-    if (rt->initial_timeout > 0)
-        rt->rtsp_flags |= RTSP_FLAG_LISTEN;
-
     if (rt->rtsp_flags & RTSP_FLAG_LISTEN) {
         ret = rtsp_listen(s);
         if (ret)
             return ret;
     } else {
+        if (rt->initial_timeout == -1)
+            rt->initial_timeout = RTSP_DEFAULT_READ_PACKET_TIMEOUT_S;
+
         ret = ff_rtsp_connect(s);
         if (ret)
             return ret;


### PR DESCRIPTION
Allow a user to specify the time (in seconds) to wait until the rtsp connection
to a server is considered inactive. After the timeout, the connection will be
terminated with `ETIMEOUT`. By default, the connection timeout is set to 10
seconds. The timeout value is set using the `timeout' command line argument.

Issue: https://trac.ffmpeg.org/ticket/2294

Notes: it is possible that the timeout that occurred is as long as twice the
specified value. The reason is that when UDP is used, the rtsp implementation
will use TCP as a fallback. The fallback connection resets the timeout_cnt, which
will result in the twice the specified value. This issue could be fixed, but it's better
to address that in a seperate commit / PR.
