### PR TITLE
Set AVCodecContext->codec upon initialization.

### DIFF
--- a/libavcodec/options.c
+++ b/libavcodec/options.c
@@ -96,7 +96,10 @@ int avcodec_get_context_defaults3(AVCodecContext *s, const AVCodec *codec)
 
     s->codec_type = codec ? codec->type : AVMEDIA_TYPE_UNKNOWN;
     if (codec)
+    {
+        s->codec = codec;
         s->codec_id = codec->id;
+    }
 
     if(s->codec_type == AVMEDIA_TYPE_AUDIO)
         flags= AV_OPT_FLAG_AUDIO_PARAM;


### PR DESCRIPTION
As far as i understand, currently we have to initialize AVCodecContext->codec manually, in order to be able to call av_opt_set.

```
AVStream* stream = avformat_new_stream(output_context, codec);
stream->codec->codec = codec; // // Otherwise next line fails, because stream->codec->codec is null
av_opt_set( stream->codec, "tune", "zerolatency", AV_OPT_SEARCH_CHILDREN ); 
```

That's weird because avcodec_get_context_defaults3 has AVCodec\* in parameter.

FATE is ok with that.
