### PR TITLE
Fix windows media player doesn't play mp3 in asf_stream (MMSH protocol)

### DIFF
--- a/libavformat/asfenc.c
+++ b/libavformat/asfenc.c
@@ -510,7 +510,11 @@ static int asf_write_header1(AVFormatContext *s, int64_t file_size,
         hpos = put_header(pb, &ff_asf_stream_header);
         if (enc->codec_type == AVMEDIA_TYPE_AUDIO) {
             ff_put_guid(pb, &ff_asf_audio_stream);
-            ff_put_guid(pb, &ff_asf_audio_conceal_spread);
+            if (enc->codec_id == AV_CODEC_ID_MP3) {
+                ff_put_guid(pb, &ff_asf_audio_conceal_none);
+            } else {
+                ff_put_guid(pb, &ff_asf_audio_conceal_spread);
+            }
         } else {
             ff_put_guid(pb, &ff_asf_video_stream);
             ff_put_guid(pb, &ff_asf_video_conceal_none);


### PR DESCRIPTION
mp3 in asf_stream can not be played at VBR mode.
mp3 in asf_stream can be played at CBR mode or ABR mode.
It was tested by S2MMSH.
https://github.com/shinji3/S2MMSH/releases