### PR TITLE
vf_showinfo: minimum widths for some early fields

### DIFF
--- a/libavfilter/vf_showinfo.c
+++ b/libavfilter/vf_showinfo.c
@@ -104,7 +104,7 @@ static int filter_frame(AVFilterLink *inlink, AVFrame *frame)
     }
 
     av_log(ctx, AV_LOG_INFO,
-           "n:%"PRId64" pts:%s pts_time:%s pos:%"PRId64" "
+           "n:%4"PRId64" pts:%7s pts_time:%-7s pos:%9"PRId64" "
            "fmt:%s sar:%d/%d s:%dx%d i:%c iskey:%d type:%c "
            "checksum:%08"PRIX32" plane_checksum:[%08"PRIX32,
            inlink->frame_count,


### PR DESCRIPTION
Depending on FPS, the pts_time string often changes length:
... pts_time:36.1 ...
... pts_time:36.1333 ...
etc.

 This makes the output bounce around horribly, making it hard to
scan down a column farther right than pts_time.

This fixes n, pts, pts_time, and pos,
but doesn't touch any of the fields in mean / stddev.

 The widths aren't intended to be wide enough that they're never
exceeded, but you'll see only an occasional ripple to a new alignment,
rather than bouncing.  (Some fields, like pos, increase monotonically,
which is why I left the minimum width for the field be smaller than it
often gets to.)