### PR TITLE
av_dict: handle keys with no value for x264/x264 opts

### DIFF
--- a/libavcodec/libx264.c
+++ b/libavcodec/libx264.c
@@ -318,20 +318,6 @@ static av_cold int X264_close(AVCodecContext *avctx)
     return 0;
 }
 
-#define OPT_STR(opt, param)                                                   \
-    do {                                                                      \
-        int ret;                                                              \
-        if (param && (ret = x264_param_parse(&x4->params, opt, param)) < 0) { \
-            if(ret == X264_PARAM_BAD_NAME)                                    \
-                av_log(avctx, AV_LOG_ERROR,                                   \
-                        "bad option '%s': '%s'\n", opt, param);               \
-            else                                                              \
-                av_log(avctx, AV_LOG_ERROR,                                   \
-                        "bad value for '%s': '%s'\n", opt, param);            \
-            return -1;                                                        \
-        }                                                                     \
-    } while (0)
-
 static int convert_pix_fmt(enum AVPixelFormat pix_fmt)
 {
     switch (pix_fmt) {
@@ -364,9 +350,36 @@ static int convert_pix_fmt(enum AVPixelFormat pix_fmt)
 
 #define PARSE_X264_OPT(name, var)\
     if (x4->var && x264_param_parse(&x4->params, name, x4->var) < 0) {\
-        av_log(avctx, AV_LOG_ERROR, "Error parsing option '%s' with value '%s'.\n", name, x4->var);\
+        av_log(avctx, AV_LOG_ERROR, "Error setting option '%s' with value '%s'.\n", name, x4->var);\
         return AVERROR(EINVAL);\
     }
+
+
+#define OPT_STR(opt, param)                                                   \
+    do {                                                                      \
+        int ret;                                                              \
+        if (param && (ret = x264_param_parse(&x4->params, opt, param)) != 0){ \
+            if(ret == X264_PARAM_BAD_NAME)                                    \
+                av_log(avctx, AV_LOG_ERROR,                                   \
+                        "bad option '%s': '%s'\n", opt, param);               \
+            else                                                              \
+                av_log(avctx, AV_LOG_ERROR,                                   \
+                        "bad value for '%s': '%s'\n", opt, param);            \
+            return -1;                                                        \
+        }                                                                     \
+    } while (0)
+
+//static av_cold int x264_parse_optstring(AVDictionary **dict, const char *str)
+#define PARSE_OPTSTR_RETURN_ON_ERROR(dict, str)                         \
+    do {                                                                \
+        int parse_ret = av_dict_parse_string((dict), (str), "=", ":", 0); \
+        if (parse_ret) {                                                \
+            av_log(avctx, AV_LOG_ERROR,                                 \
+                   "can't split '%s' into key=value:key=value pairs\n", str); \
+            av_dict_free(dict);                                         \
+            return -1;                                                  \
+        }                                                               \
+    } while(0)
 
 static av_cold int X264_init(AVCodecContext *avctx)
 {
@@ -653,34 +666,49 @@ static av_cold int X264_init(AVCodecContext *avctx)
     if (avctx->flags & CODEC_FLAG_GLOBAL_HEADER)
         x4->params.b_repeat_headers = 0;
 
-    if(x4->x264opts){
-        const char *p= x4->x264opts;
-        while(p){
-            char param[256]={0}, val[256]={0};
-            if(sscanf(p, "%255[^:=]=%255[^:]", param, val) == 1){
-                OPT_STR(param, "1");
-            }else
-                OPT_STR(param, val);
-            p= strchr(p, ':');
-            p+=!!p;
-        }
-    }
+    /* why do we have two ways to pass : separated options lists,
+     * one with ' and \ quoting support, one without?
+     * never-committed attempt to fix this
+     * http://ffmpeg.org/pipermail/ffmpeg-devel/2013-July/146329.html
+     */
 
-    if (x4->x264_params) {
+    if (x4->x264opts || x4->x264_params) {
+        // libx265.c has a similar code block for parsing its param string
+        // but it doesn't have two separate options for option strings
         AVDictionary *dict    = NULL;
         AVDictionaryEntry *en = NULL;
+        int parse_ret;
 
-        if (!av_dict_parse_string(&dict, x4->x264_params, "=", ":", 0)) {
-            while ((en = av_dict_get(dict, "", en, AV_DICT_IGNORE_SUFFIX))) {
-                if (x264_param_parse(&x4->params, en->key, en->value) < 0)
-                    av_log(avctx, AV_LOG_WARNING,
-                           "Error parsing option '%s = %s'.\n",
-                            en->key, en->value);
+        if (x4->x264opts)
+            PARSE_OPTSTR_RETURN_ON_ERROR(&dict, x4->x264opts);
+
+        if (x4->x264_params) // merge into the same dictionary
+            PARSE_OPTSTR_RETURN_ON_ERROR(&dict, x4->x264_params);
+
+        while ((en = av_dict_get(dict, "", en, AV_DICT_IGNORE_SUFFIX))) {
+            char *tmpval = en->value;  // we need NULLs, not empty strings,
+            if ('\0' == *tmpval) tmpval = NULL; // for the no-value case
+            parse_ret = x264_param_parse(&x4->params, en->key, tmpval);
+
+            switch (parse_ret) {
+            case 0:
+                break;
+            case X264_PARAM_BAD_NAME:
+                av_log(avctx, AV_LOG_WARNING,
+                       "Unknown option: '%s'.\n", en->key);
+                return parse_ret;
+                break;
+            case X264_PARAM_BAD_VALUE:
+            default:
+                av_log(avctx, AV_LOG_WARNING,
+                       "Invalid value for '%s' = '%s'.\n", en->key, en->value);
+                return parse_ret;
+                break;
             }
-
-            av_dict_free(&dict);
         }
+        av_dict_free(&dict);
     }
+
 
     // update AVCodecContext with x264 parameters
     avctx->has_b_frames = x4->params.i_bframe ?

--- a/libavutil/avstring.c
+++ b/libavutil/avstring.c
@@ -171,15 +171,16 @@ char *av_get_token(const char **buf, const char *term)
             *out++ = c;
         }
     }
+    *buf = p;  // advance caller's position to the end of the returned token
 
-    do
+    do  // kill non-quoted trailing whitespace
         *out-- = 0;
     while (out >= end_quote && strchr(WHITESPACES, *out));
 
-    *buf = p;
-    // +1 for nul byte, +1 to counteract do {} while extra decrement
-    ret = av_realloc(ret, out - ret + 2);
-    // if realloc fails to shrink, we're hosed anyway; just leak the old buffer
+    // +1 for nul byte, +1 to counteract the do {} while extra decrement
+    out = av_realloc(ret, out - ret + 2);
+    if (out)  // we're only ever shrinking, so we don't have to error on fail
+        ret = out;
     return ret;
 }
 

--- a/libavutil/avstring.c
+++ b/libavutil/avstring.c
@@ -148,24 +148,24 @@ char *av_d2str(double d)
 
 char *av_get_token(const char **buf, const char *term)
 {
-    char *out     = av_malloc(strlen(*buf) + 1);
-    char *ret     = out, *end = out;
+    char *out     = av_realloc(NULL, strlen(*buf) + 1); // av_malloc isn't safe for realloc
+    char *ret     = out, *end_quote = out;
     const char *p = *buf;
     if (!out)
         return NULL;
     p += strspn(p, WHITESPACES);
 
-    while (*p && !strspn(p, term)) {
+    while (*p && !strchr(term, *p)) {
         char c = *p++;
         if (c == '\\' && *p) {
             *out++ = *p++;
-            end    = out;
+            end_quote    = out;
         } else if (c == '\'') {
             while (*p && *p != '\'')
                 *out++ = *p++;
             if (*p) {
                 p++;
-                end = out;
+                end_quote = out;
             }
         } else {
             *out++ = c;
@@ -174,10 +174,12 @@ char *av_get_token(const char **buf, const char *term)
 
     do
         *out-- = 0;
-    while (out >= end && strspn(out, WHITESPACES));
+    while (out >= end_quote && strchr(WHITESPACES, *out));
 
     *buf = p;
-
+    // +1 for nul byte, +1 to counteract do {} while extra decrement
+    ret = av_realloc(ret, out - ret + 2);
+    // if realloc fails to shrink, we're hosed anyway; just leak the old buffer
     return ret;
 }
 

--- a/libavutil/avstring.h
+++ b/libavutil/avstring.h
@@ -171,7 +171,7 @@ char *av_d2str(double d);
  * @param buf the buffer to parse, buf will be updated to point to the
  * terminating char
  * @param term a 0-terminated list of terminating chars
- * @return the malloced unescaped string, which must be av_freed by
+ * @return the av_realloced unescaped string, which must be av_freed by
  * the user, NULL in case of allocation failure
  */
 char *av_get_token(const char **buf, const char *term);

--- a/libavutil/dict.c
+++ b/libavutil/dict.c
@@ -151,24 +151,25 @@ int av_dict_set_int(AVDictionary **pm, const char *key, int64_t value,
 
 static int parse_key_value_pair(AVDictionary **pm, const char **buf,
                                 const char *key_val_sep, const char *pairs_sep,
-                                int flags)
+                                const char *all_sep, int flags)
 {
-    char *key = av_get_token(buf, key_val_sep);
-    char *val = NULL;
+    char *key, *val = NULL;
     int ret;
 
-    if (key && *key && strspn(*buf, key_val_sep)) {
-        (*buf)++;
-        val = av_get_token(buf, pairs_sep);
+    key = av_get_token(buf, all_sep);
+    if (key && *key) {
+        if (strchr(key_val_sep, **buf))
+            (*buf)++;    // skip over the = to get to val
+        val = av_get_token(buf, pairs_sep); // will be "" if a sep is next
+
+        if (val) // av_get_token reallocs to the min length needed, so don't re-dup
+            ret = av_dict_set(pm, key, val, flags | AV_DICT_DONT_STRDUP_KEY | AV_DICT_DONT_STRDUP_VAL);
+        else {
+            ret = AVERROR(EINVAL);
+            av_freep(&key);
+            av_freep(&val);
+        }
     }
-
-    if (key && *key && val && *val)
-        ret = av_dict_set(pm, key, val, flags);
-    else
-        ret = AVERROR(EINVAL);
-
-    av_freep(&key);
-    av_freep(&val);
 
     return ret;
 }
@@ -178,15 +179,16 @@ int av_dict_parse_string(AVDictionary **pm, const char *str,
                          int flags)
 {
     int ret;
+    char all_sep[16];
 
     if (!str)
         return 0;
 
-    /* ignore STRDUP flags */
-    flags &= ~(AV_DICT_DONT_STRDUP_KEY | AV_DICT_DONT_STRDUP_VAL);
+    av_strlcpy(all_sep, key_val_sep, sizeof(all_sep));
+    av_strlcat(all_sep, pairs_sep, sizeof(all_sep));
 
     while (*str) {
-        if ((ret = parse_key_value_pair(pm, &str, key_val_sep, pairs_sep, flags)) < 0)
+        if ((ret = parse_key_value_pair(pm, &str, key_val_sep, pairs_sep, all_sep, flags)) < 0)
             return ret;
 
         if (*str)

--- a/libavutil/dict.c
+++ b/libavutil/dict.c
@@ -158,7 +158,7 @@ static int parse_key_value_pair(AVDictionary **pm, const char **buf,
 
     key = av_get_token(buf, all_sep);
     if (key && *key) {
-        if (strchr(key_val_sep, **buf))
+        if (**buf && strchr(key_val_sep, **buf))
             (*buf)++;    // skip over the = to get to val
         val = av_get_token(buf, pairs_sep); // will be "" if a sep is next
     }

--- a/libavutil/dict.c
+++ b/libavutil/dict.c
@@ -161,14 +161,13 @@ static int parse_key_value_pair(AVDictionary **pm, const char **buf,
         if (strchr(key_val_sep, **buf))
             (*buf)++;    // skip over the = to get to val
         val = av_get_token(buf, pairs_sep); // will be "" if a sep is next
+    }
 
-        if (val) // av_get_token reallocs to the min length needed, so don't re-dup
+    if (val) // av_get_token reallocs to the min length needed, so don't re-dup
             ret = av_dict_set(pm, key, val, flags | AV_DICT_DONT_STRDUP_KEY | AV_DICT_DONT_STRDUP_VAL);
-        else {
-            ret = AVERROR(EINVAL);
-            av_freep(&key);
-            av_freep(&val);
-        }
+    else {
+        ret = AVERROR(EINVAL);
+        av_freep(&key);
     }
 
     return ret;
@@ -191,7 +190,7 @@ int av_dict_parse_string(AVDictionary **pm, const char *str,
         if ((ret = parse_key_value_pair(pm, &str, key_val_sep, pairs_sep, all_sep, flags)) < 0)
             return ret;
 
-        if (*str)
+        if (*str) // allows a trailing pairs_sep
             str++;
     }
 

--- a/libavutil/dict.c
+++ b/libavutil/dict.c
@@ -166,7 +166,7 @@ static int parse_key_value_pair(AVDictionary **pm, const char **buf,
     if (val) // av_get_token reallocs to the min length needed, so don't re-dup
             ret = av_dict_set(pm, key, val, flags | AV_DICT_DONT_STRDUP_KEY | AV_DICT_DONT_STRDUP_VAL);
     else {
-        ret = AVERROR(EINVAL);
+        ret = AVERROR(EINVAL);  // error only on empty key or malloc fail
         av_freep(&key);
     }
 

--- a/libavutil/dict.h
+++ b/libavutil/dict.h
@@ -137,6 +137,8 @@ int av_dict_set_int(AVDictionary **pm, const char *key, int64_t value, int flags
 
 /**
  * Parse the key/value pairs list and add the parsed entries to a dictionary.
+ * keys with no value will have av_mallo()ced empty strings as their value.
+ * (e.g. key1:key2=val2:key3) parsed with "=", ":"
  *
  * In case of failure, all the successfully set entries are stored in
  * *pm. You may need to manually free the created dictionary.
@@ -145,6 +147,7 @@ int av_dict_set_int(AVDictionary **pm, const char *key, int64_t value, int flags
  *                     key from value
  * @param pairs_sep    a 0-terminated list of characters used to separate
  *                     two pairs from each other
+ *                     strlen(key_val_sep) + strlen(pairs_sep) must be < 16
  * @param flags        flags to use when adding to dictionary.
  *                     AV_DICT_DONT_STRDUP_KEY and AV_DICT_DONT_STRDUP_VAL
  *                     are ignored since the key/value tokens will always


### PR DESCRIPTION
I'm posting this to see if a change like this would be considered, before I spend more time cleaning it up.  I've been using it locally for a couple months without anything breaking, but I don't use many different features of ffmpeg.

The first several patches just add support to av_dict, then the x26x-opts branch of patches uses it.

 If we want this change, I will tidy up some commit messages, and maybe split the changes to libx264.c into multiple commits.  (Now, it combines handling for x264-params and x264opts as well as adding separate support for empty values.)  Also, just realized that it probably still doesn't work to have 'tune=animation:tune=gain:tune=ssim', and now you can't use x264-params and x264opts separately to hack around it by getting two different calls with tune= parameters.  I haven't checked on the handling of the -tune command line option.

fixes https://trac.ffmpeg.org/ticket/4284#comment:2

More readable than Michael's quick hack with some weird swap stuff (http://ffmpeg.org/pipermail/ffmpeg-devel/2013-July/146362.html).  Although if adding a new flag to av_dict is ok, it would simplify the x264/x265 drivers to not have to translate empty strings into NULL pointers.  And also avoid changing the behaviour for callers that DON'T pass that flag, in case any callers depended on rejecting "key:key".
