### PR TITLE
3 minor patches: x264 AQ options help updates, and 2 comments updates

### DIFF
--- a/libavcodec/libx264.c
+++ b/libavcodec/libx264.c
@@ -784,7 +784,10 @@ static const AVOption options[] = {
     { "aq-mode",       "AQ method",                                       OFFSET(aq_mode),       AV_OPT_TYPE_INT,    { .i64 = -1 }, -1, INT_MAX, VE, "aq_mode"},
     { "none",          NULL,                              0, AV_OPT_TYPE_CONST, {.i64 = X264_AQ_NONE},         INT_MIN, INT_MAX, VE, "aq_mode" },
     { "variance",      "Variance AQ (complexity mask)",   0, AV_OPT_TYPE_CONST, {.i64 = X264_AQ_VARIANCE},     INT_MIN, INT_MAX, VE, "aq_mode" },
-    { "autovariance",  "Auto-variance AQ (experimental)", 0, AV_OPT_TYPE_CONST, {.i64 = X264_AQ_AUTOVARIANCE}, INT_MIN, INT_MAX, VE, "aq_mode" },
+    { "autovariance",  "Auto-variance AQ",                0, AV_OPT_TYPE_CONST, {.i64 = X264_AQ_AUTOVARIANCE}, INT_MIN, INT_MAX, VE, "aq_mode" },
+#if X264_BUILD >= 144
+    { "autovariance-biased", "Auto-variance AQ with bias to dark scenes", 0, AV_OPT_TYPE_CONST, {.i64 = X264_AQ_AUTOVARIANCE_BIASED}, INT_MIN, INT_MAX, VE, "aq_mode" },
+#endif
     { "aq-strength",   "AQ strength. Reduces blocking and blurring in flat and textured areas.", OFFSET(aq_strength), AV_OPT_TYPE_FLOAT, {.dbl = -1}, -1, FLT_MAX, VE},
     { "psy",           "Use psychovisual optimizations.",                 OFFSET(psy),           AV_OPT_TYPE_INT,    { .i64 = -1 }, -1, 1, VE },
     { "psy-rd",        "Strength of psychovisual optimization, in <psy-rd>:<psy-trellis> format.", OFFSET(psy_rd), AV_OPT_TYPE_STRING,  {0 }, 0, 0, VE},

--- a/libavutil/pixdesc.h
+++ b/libavutil/pixdesc.h
@@ -93,9 +93,9 @@ typedef struct AVPixFmtDescriptor {
      * Parameters that describe how pixels are packed.
      * If the format has 2 or 4 components, then alpha is last.
      * If the format has 1 or 2 components, then luma is 0.
-     * If the format has 3 or 4 components,
-     * if the RGB flag is set then 0 is red, 1 is green and 2 is blue;
-     * otherwise 0 is luma, 1 is chroma-U and 2 is chroma-V.
+     * If the format has 3 or 4 components:
+     *   if the RGB flag is set then 0 is red, 1 is green and 2 is blue;
+     *   otherwise 0 is luma, 1 is chroma-U and 2 is chroma-V.
      */
     AVComponentDescriptor comp[4];
 

--- a/libavutil/x86/pixelutils_init.c
+++ b/libavutil/x86/pixelutils_init.c
@@ -43,6 +43,12 @@ void ff_pixelutils_sad_init_x86(av_pixelutils_sad_fn *sad, int aligned)
         sad[2] = ff_pixelutils_sad_8x8_mmx;
     }
 
+    // The best way to use SSE2 would be to do 2 SADs in parallel,
+    // but we'd have to modify the pixelutils API to return SIMD functions.
+
+    // It's probably not faster to shuffle data around
+    // to get two lines of 8 pixels into a single 16byte register,
+    // so just use the MMX 8x8 version even when SSE2 is available.
     if (EXTERNAL_MMXEXT(cpu_flags)) {
         sad[2] = ff_pixelutils_sad_8x8_mmxext;
         sad[3] = ff_pixelutils_sad_16x16_mmxext;


### PR DESCRIPTION
IDK if I should have made 3 separate branches for 3 separate pull requests for each of these trivial patches.

I added the comment on sad_8x8_sse2, since I wondered why there wasn't one, when looking at mpdecimate, and spent some time googling.  Either or both of the comment patches might save someone else some time.
