### PR TITLE
Add av_dump_format without the url parameter

### DIFF
--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -3602,6 +3602,10 @@ static int process_input(int file_index)
             pkt.dts -= 1ULL<<ist->st->pts_wrap_bits;
             ist->wrap_correction_done = 0;
         }
+        if(stime2 > stime && pkt.pts != AV_NOPTS_VALUE && pkt.pts > stime + (1LL<<(ist->st->pts_wrap_bits-1))) {
+-            pkt.pts -= 1ULL<<ist->st->pts_wrap_bits;
+-            ist->wrap_correction_done = 0;
+-        }
     }
 
     /* add the stream-global side data to the first packet */

--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -3602,10 +3602,6 @@ static int process_input(int file_index)
             pkt.dts -= 1ULL<<ist->st->pts_wrap_bits;
             ist->wrap_correction_done = 0;
         }
-        if(stime2 > stime && pkt.pts != AV_NOPTS_VALUE && pkt.pts > stime + (1LL<<(ist->st->pts_wrap_bits-1))) {
-            pkt.pts -= 1ULL<<ist->st->pts_wrap_bits;
-            ist->wrap_correction_done = 0;
-        }
     }
 
     /* add the stream-global side data to the first packet */

--- a/libavformat/avformat.h
+++ b/libavformat/avformat.h
@@ -2506,6 +2506,13 @@ void av_dump_format(AVFormatContext *ic,
                     int is_output);
 
 /**
+ * Alias to default av_dump_format using ic->filename as url
+ */
+void av_dump_format(AVFormatContext *ic,
+                    int index,
+                    int is_output);
+
+/**
  * Return in 'buf' the path with '%d' replaced by a number.
  *
  * Also handles the '%0nd' format where 'n' is the total number

--- a/libavformat/dump.c
+++ b/libavformat/dump.c
@@ -425,6 +425,11 @@ static void dump_stream_format(AVFormatContext *ic, int i,
     dump_sidedata(NULL, st, "    ");
 }
 
+void av_dump_format(AVFormatContext *ic, int index, int is_output)
+{
+    av_dump_format(ic, index, ic->filename, is_output);
+}
+
 void av_dump_format(AVFormatContext *ic, int index,
                     const char *url, int is_output)
 {


### PR DESCRIPTION
After trying different approaches to get it work the way I need, I noticed I always use the url parameter of av_dump_format as the filename attribute of the AVFormatContext.