### PR TITLE
Make compilable with VS2015

### DIFF
--- a/configure
+++ b/configure
@@ -3531,7 +3531,9 @@ probe_cc(){
         _flags='-nologo'
         _cflags='-D_USE_MATH_DEFINES -D_CRT_SECURE_NO_WARNINGS -Dinline=__inline -FIstdlib.h -Dstrtoll=_strtoi64'
         if [ $pfx = hostcc ]; then
-            append _cflags -Dsnprintf=_snprintf
+            if [ -z "$cl_major_ver" ] || [ $cl_major_ver -le 18 ]; then
+                append _cflags -Dsnprintf=_snprintf
+            fi
         fi
         disable stripping
     elif $_cc --version 2>/dev/null | grep -q ^cparser; then
@@ -4318,10 +4320,12 @@ case $libc_type in
         add_compat strtod.o strtod=avpriv_strtod
         ;;
     msvcrt)
-        add_compat strtod.o strtod=avpriv_strtod
-        add_compat msvcrt/snprintf.o snprintf=avpriv_snprintf   \
-                                     _snprintf=avpriv_snprintf  \
-                                     vsnprintf=avpriv_vsnprintf
+        if [ -z "$cl_major_ver" ] || [ $cl_major_ver -le 18 ]; then
+            add_compat strtod.o strtod=avpriv_strtod
+            add_compat msvcrt/snprintf.o snprintf=avpriv_snprintf   \
+                                         _snprintf=avpriv_snprintf  \
+                                         vsnprintf=avpriv_vsnprintf
+        fi
         ;;
 esac
 

--- a/libavutil/internal.h
+++ b/libavutil/internal.h
@@ -164,7 +164,7 @@
 
 #include "libm.h"
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && _MSC_VER < 1900
 #pragma comment(linker, "/include:"EXTERN_PREFIX"avpriv_strtod")
 #pragma comment(linker, "/include:"EXTERN_PREFIX"avpriv_snprintf")
 #endif


### PR DESCRIPTION
So Visual Studio 2015 has some breaking changes regarding the C
runtime. In short, they made C99 compatable runtime.
Refer to http://blogs.msdn.com/b/vcblog/archive/2014/06/18/crt-features-fixes-and-breaking-changes-in-visual-studio-14-ctp1.aspx