### PR TITLE
Hls flag additions

### DIFF
--- a/libavformat/hlsenc.c
+++ b/libavformat/hlsenc.c
@@ -293,7 +293,7 @@ static int hls_window(AVFormatContext *s, int last)
         avio_printf(out, "%s\n", en->filename);
     }
 
-    if (last)
+    if (last && (hls->flags & HLS_OMIT_ENDLIST)==0)
         avio_printf(out, "#EXT-X-ENDLIST\n");
 
 fail:
@@ -524,6 +524,7 @@ static const AVOption options[] = {
     {"delete_segments", "delete segment files that are no longer part of the playlist", 0, AV_OPT_TYPE_CONST, {.i64 = HLS_DELETE_SEGMENTS }, 0, UINT_MAX,   E, "flags"},
     {"round_durations", "round durations in m3u8 to whole numbers", 0, AV_OPT_TYPE_CONST, {.i64 = HLS_ROUND_DURATIONS }, 0, UINT_MAX,   E, "flags"},
     {"discont_start", "Start the m3u8 with a discontinuity", 0, AV_OPT_TYPE_CONST, {.i64 = HLS_DISCONT_START }, 0, UINT_MAX,   E, "flags"},
+    {"omit_endlist", "Do not append an endlist when ending stream", 0, AV_OPT_TYPE_CONST, {.i64 = HLS_OMIT_ENDLIST }, 0, UINT_MAX,   E, "flags"},
 
     { NULL },
 };

--- a/libavformat/hlsenc.c
+++ b/libavformat/hlsenc.c
@@ -50,6 +50,7 @@ typedef enum HLSFlags {
     // Generate a single media file and use byte ranges in the playlist.
     HLS_SINGLE_FILE = (1 << 0),
     HLS_DELETE_SEGMENTS = (1 << 1),
+    HLS_ROUND_DURATIONS = (1 << 2),
 } HLSFlags;
 
 typedef struct HLSContext {
@@ -274,7 +275,10 @@ static int hls_window(AVFormatContext *s, int last)
            sequence);
 
     for (en = hls->segments; en; en = en->next) {
-        avio_printf(out, "#EXTINF:%f,\n", en->duration);
+        if (hls->flags & HLS_ROUND_DURATIONS)
+            avio_printf(out, "#EXTINF:%d,\n",  (int)round(en->duration));
+        else
+            avio_printf(out, "#EXTINF:%f,\n", en->duration);
         if (hls->flags & HLS_SINGLE_FILE)
              avio_printf(out, "#EXT-X-BYTERANGE:%"PRIi64"@%"PRIi64"\n",
                          en->size, en->pos);
@@ -512,7 +516,9 @@ static const AVOption options[] = {
     {"hls_flags",     "set flags affecting HLS playlist and media file generation", OFFSET(flags), AV_OPT_TYPE_FLAGS, {.i64 = 0 }, 0, UINT_MAX, E, "flags"},
     {"single_file",   "generate a single media file indexed with byte ranges", 0, AV_OPT_TYPE_CONST, {.i64 = HLS_SINGLE_FILE }, 0, UINT_MAX,   E, "flags"},
     {"delete_segments", "delete segment files that are no longer part of the playlist", 0, AV_OPT_TYPE_CONST, {.i64 = HLS_DELETE_SEGMENTS }, 0, UINT_MAX,   E, "flags"},
+    {"round_durations", "round durations in m3u8 to whole numbers", 0, AV_OPT_TYPE_CONST, {.i64 = HLS_ROUND_DURATIONS }, 0, UINT_MAX,   E, "flags"},
 
+    
     { NULL },
 };
 

--- a/libavformat/hlsenc.c
+++ b/libavformat/hlsenc.c
@@ -52,6 +52,7 @@ typedef enum HLSFlags {
     HLS_DELETE_SEGMENTS = (1 << 1),
     HLS_ROUND_DURATIONS = (1 << 2),
     HLS_DISCONT_START = (1 << 3),
+    HLS_OMIT_ENDLIST = (1 << 4),
 } HLSFlags;
 
 typedef struct HLSContext {


### PR DESCRIPTION
+round_durations, fixes playback on some hls enabled devices that do not like float values
+discont_start , starts a m3u8 with a discontinuity, helpful when emulating /creating live feeds
+omit_endlist, omits the m3u8 ENDLIST, helpful when emulating /creating live feeds