### PR TITLE
Dynamic loading of filters as independent objects.

### DIFF
--- a/configure
+++ b/configure
@@ -196,6 +196,7 @@ External library support:
   --disable-bzlib          disable bzlib [autodetect]
   --enable-fontconfig      enable fontconfig, useful for drawtext filter [no]
   --enable-frei0r          enable frei0r video filtering [no]
+  --enable-dynamic-filter  enable dynamic filters loading for development purpose [no]
   --enable-gnutls          enable gnutls, needed for https support
                            if openssl is not used [no]
   --disable-iconv          disable iconv [autodetect]
@@ -1510,6 +1511,7 @@ CONFIG_LIST="
     raise_major
     thumb
     xmm_clobber_test
+    dynamic_filter
 "
 
 THREADS_LIST="
@@ -2623,6 +2625,8 @@ fftfilt_filter_select="rdft"
 flite_filter_deps="libflite"
 frei0r_filter_deps="frei0r dlopen"
 frei0r_src_filter_deps="frei0r dlopen"
+dynamic_filter_filter_deps="dlopen"
+dynamic_filter_src_filter_deps="dlopen"
 fspp_filter_deps="gpl"
 geq_filter_deps="gpl"
 histeq_filter_deps="gpl"
@@ -4746,6 +4750,8 @@ fi
 
 frei0r_filter_extralibs='$ldl'
 frei0r_src_filter_extralibs='$ldl'
+dynamic_filter_filter_extralibs='$ldl'
+dynamic_filter_src_filter_extralibs='$ldl'
 ladspa_filter_extralibs='$ldl'
 nvenc_encoder_extralibs='$ldl'
 
@@ -4934,6 +4940,7 @@ enabled avisynth          && { { check_lib2 "windows.h" LoadLibrary; } ||
                                die "ERROR: LoadLibrary/dlopen not found for avisynth"; }
 enabled decklink          && { check_header DeckLinkAPI.h || die "ERROR: DeckLinkAPI.h header not found"; }
 enabled frei0r            && { check_header frei0r.h || die "ERROR: frei0r.h header not found"; }
+enabled dynamic_filter    && { check_header dlfcn.h || die "ERROR: dlfcn.h header not found"; }
 enabled gnutls            && require_pkg_config gnutls gnutls/gnutls.h gnutls_global_init
 enabled ladspa            && { check_header ladspa.h || die "ERROR: ladspa.h header not found"; }
 enabled libiec61883       && require libiec61883 libiec61883/iec61883.h iec61883_cmp_connect -lraw1394 -lavc1394 -lrom1394 -liec61883

--- a/libavfilter/Makefile
+++ b/libavfilter/Makefile
@@ -1,5 +1,12 @@
 include $(SUBDIR)../config.mak
 
+ifneq ($(CONFIG_DYNAMIC_FILTER),yes)
+SHFLAGS=-shared -Wl,-soname,$$(@F) -Wl,-Bsymbolic -Wl,--version-script,$(SUBDIR)lib$(NAME).ver
+else
+SHFLAGS=-shared -Wl,-soname,$$(@F) -Wl,-Bsymbolic
+endif
+
+
 NAME = avfilter
 
 HEADERS = asrc_abuffer.h                                                \

--- a/libavfilter/allfilters.c
+++ b/libavfilter/allfilters.c
@@ -19,13 +19,17 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <dlfcn.h>
-#include <unistd.h>
-
 #include "avfilter.h"
 #include "config.h"
 #include "opencl_allkernels.h"
 
+#if CONFIG_DYNAMIC_FILTER
+#include <dlfcn.h>
+#include <unistd.h>
+#include <dirent.h>
+#include <string.h>
+#include <sys/types.h>
+#endif
 
 #define REGISTER_FILTER(X, x, y)                                        \
     {                                                                   \
@@ -275,19 +279,50 @@ void avfilter_register_all(void)
     REGISTER_FILTER_UNCONDITIONAL(af_afifo);
     REGISTER_FILTER_UNCONDITIONAL(vf_fifo);
 
-    {
+#if CONFIG_DYNAMIC_FILTER
+    do {
         void *handle;
         AVFilter *ld_filter;
 
-        write(1,"\nZER\n", 5);
-        if (!(handle = dlopen("cockpit.so", RTLD_LAZY)))
-            return;
-        write(1,"\nONE\n", 5);
-        if ((ld_filter = (AVFilter *)dlsym(handle, "ff_vf_cockpit")) == NULL)
-            return;
-        write(1,"\nTWO\n", 5);
-        avfilter_register(ld_filter);
-    }
+        char *dyndir, dynfile[PATH_MAX + 1], dynname[PATH_MAX + 1], *p;
+        DIR *dir;
+        struct dirent *dircur;
 
+
+        if ((dyndir = getenv("FFMPEG_DYN_FILTERS")) == NULL)
+            break;
+
+        if ((dir = opendir(dyndir)) == NULL)
+            break;
+
+        while ((dircur = readdir(dir)) != NULL) {
+            /* current item isn't a normal file */
+            if ((dircur->d_type == DT_REG) == 0) {
+                continue;
+            }
+            dynfile[PATH_MAX] = '\0';
+            strncpy(dynfile, dyndir, PATH_MAX);
+            strncat(dynfile, "/", PATH_MAX);
+            strncat(dynfile, dircur->d_name, PATH_MAX);
+
+            /* copy the file name and remove the extension suffix */
+            dynname[PATH_MAX] = '\0';
+            strncpy(dynname, "ff_", PATH_MAX);
+            strncat(dynname, dircur->d_name, PATH_MAX);
+            if ((p = strrchr(dynname, '.')) != NULL)
+                *p = '\0';
+
+            if (!(handle = dlopen(dynfile, RTLD_NOW|RTLD_LOCAL))) {
+                av_log(NULL, AV_LOG_WARNING, "dynamic filters: '%s' load failed\n", dynfile);
+                continue;
+            }
+            if ((ld_filter = (AVFilter *)dlsym(handle, dynname)) == NULL) {
+                av_log(NULL, AV_LOG_WARNING, "dynamic filters: symbol '%s' not found in '%s' file\n", dynname, dynfile);
+                continue;
+            }
+            avfilter_register(ld_filter);
+        } while (0);
+    } while (0);
+#endif
     ff_opencl_register_filter_kernel_code_all();
 }

--- a/libavfilter/allfilters.c
+++ b/libavfilter/allfilters.c
@@ -19,6 +19,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <dlfcn.h>
+#include <unistd.h>
+
 #include "avfilter.h"
 #include "config.h"
 #include "opencl_allkernels.h"
@@ -271,5 +274,20 @@ void avfilter_register_all(void)
     REGISTER_FILTER_UNCONDITIONAL(vsink_buffer);
     REGISTER_FILTER_UNCONDITIONAL(af_afifo);
     REGISTER_FILTER_UNCONDITIONAL(vf_fifo);
+
+    {
+        void *handle;
+        AVFilter *ld_filter;
+
+        write(1,"\nZER\n", 5);
+        if (!(handle = dlopen("cockpit.so", RTLD_LAZY)))
+            return;
+        write(1,"\nONE\n", 5);
+        if ((ld_filter = (AVFilter *)dlsym(handle, "ff_vf_cockpit")) == NULL)
+            return;
+        write(1,"\nTWO\n", 5);
+        avfilter_register(ld_filter);
+    }
+
     ff_opencl_register_filter_kernel_code_all();
 }

--- a/libavfilter/libavfilter.v
+++ b/libavfilter/libavfilter.v
@@ -1,3 +1,4 @@
 LIBAVFILTER_$MAJOR {
-        global: *;
+        global: avfilter_*; av_*;
+        local: *;
 };

--- a/libavfilter/libavfilter.v
+++ b/libavfilter/libavfilter.v
@@ -1,4 +1,3 @@
 LIBAVFILTER_$MAJOR {
-        global: avfilter_*; av_*;
-        local: *;
+        global: *;
 };

--- a/libavutil/log.h
+++ b/libavutil/log.h
@@ -219,7 +219,7 @@ typedef struct AVClass {
  * @see av_log_set_callback
  *
  * @param avcl A pointer to an arbitrary struct of which the first field is a
- *        pointer to an AVClass struct.
+ *        pointer to an AVClass struct or NULL if general log.
  * @param level The importance level of the message expressed using a @ref
  *        lavu_log_constants "Logging Constant".
  * @param fmt The format string (printf-compatible) that specifies how


### PR DESCRIPTION
Hi, my proposal is allow FFmpeg developers to be able to compile FFmpeg with the new flag "--enable-dynamic-filter" and develop filters as plugin compiled sparately.
An example of filter develop in this way: 
    https://github.com/nastasi/vf_chronograph
And an example of filter output:
    https://youtu.be/EtkLBQgTl9A
