### PR TITLE
ff_getnameinfo: fix struct servent dependancy

### DIFF
--- a/libavformat/os_support.c
+++ b/libavformat/os_support.c
@@ -209,11 +209,11 @@ int ff_getnameinfo(const struct sockaddr *sa, int salen,
 #if HAVE_GETSERVBYPORT
         if (!(flags & NI_NUMERICSERV))
             ent = getservbyport(sin->sin_port, flags & NI_DGRAM ? "udp" : "tcp");
-#endif /* HAVE_GETSERVBYPORT */
 
         if (ent)
             snprintf(serv, servlen, "%s", ent->s_name);
         else
+#endif /* HAVE_GETSERVBYPORT */
             snprintf(serv, servlen, "%d", ntohs(sin->sin_port));
     }
 


### PR DESCRIPTION
On systems lacking getservbyport, struct servent might not be defined,
causing a compilation error when trying to access its member s_name (ent->s_name).
There is no point in keeping the if(ent) branch when getservbyport is not
available.