### PR TITLE
avcodec/gifdec: skip data lzw consumed

### DIFF
--- a/libavcodec/gifdec.c
+++ b/libavcodec/gifdec.c
@@ -295,6 +295,8 @@ static int gif_read_image(GifState *s, AVFrame *frame)
     /* read the garbage data until end marker is found */
     ff_lzw_decode_tail(s->lzw);
 
+    bytestream2_skipu(&s->gb, bytestream2_get_bytes_left(&s->gb));
+
     /* Graphic Control Extension's scope is single frame.
      * Remove its influence. */
     s->transparent_color_index = -1;


### PR DESCRIPTION
this commit fix the return code value of avcodec_decode_video2 for gif decoding, which should be the consumed data length.