### PR TITLE
movenc: support cenc (common encryption)

### DIFF
--- a/libavformat/Makefile
+++ b/libavformat/Makefile
@@ -264,7 +264,7 @@ OBJS-$(CONFIG_MMF_DEMUXER)               += mmf.o
 OBJS-$(CONFIG_MMF_MUXER)                 += mmf.o rawenc.o
 OBJS-$(CONFIG_MOV_DEMUXER)               += mov.o isom.o mov_chan.o replaygain.o
 OBJS-$(CONFIG_MOV_MUXER)                 += movenc.o isom.o avc.o hevc.o \
-                                            movenchint.o mov_chan.o rtp.o
+                                            movenchint.o mov_chan.o rtp.o movenccenc.o
 OBJS-$(CONFIG_MP2_MUXER)                 += mp3enc.o rawenc.o id3v2enc.o
 OBJS-$(CONFIG_MP3_DEMUXER)               += mp3dec.o replaygain.o
 OBJS-$(CONFIG_MP3_MUXER)                 += mp3enc.o rawenc.o id3v2enc.o

--- a/libavformat/movenc.c
+++ b/libavformat/movenc.c
@@ -5157,6 +5157,12 @@ static int mov_write_header(AVFormatContext *s)
         mov->nb_streams += mov->nb_meta_tmcd;
     }
 
+    // Reserve an extra stream for chapters for the case where chapters
+    // are written in the trailer
+    mov->tracks = av_mallocz_array((mov->nb_streams + 1), sizeof(*mov->tracks));
+    if (!mov->tracks)
+        return AVERROR(ENOMEM);
+    
     if (mov->encryption_scheme_str != NULL && strcmp(mov->encryption_scheme_str, "none") != 0) {
         if (strcmp(mov->encryption_scheme_str, "cenc-aes-ctr") == 0) {
             mov->encryption_scheme = MOV_ENC_CENC_AES_CTR;
@@ -5182,12 +5188,6 @@ static int mov_write_header(AVFormatContext *s)
             goto error;
         }
     }
-
-    // Reserve an extra stream for chapters for the case where chapters
-    // are written in the trailer
-    mov->tracks = av_mallocz_array((mov->nb_streams + 1), sizeof(*mov->tracks));
-    if (!mov->tracks)
-        return AVERROR(ENOMEM);
 
     for (i = 0; i < s->nb_streams; i++) {
         AVStream *st= s->streams[i];

--- a/libavformat/movenc.h
+++ b/libavformat/movenc.h
@@ -25,6 +25,7 @@
 #define AVFORMAT_MOVENC_H
 
 #include "avformat.h"
+#include "movenccenc.h"
 
 #define MOV_FRAG_INFO_ALLOC_INCREMENT 64
 #define MOV_INDEX_CLUSTER_SIZE 1024
@@ -149,7 +150,14 @@ typedef struct MOVTrack {
     } vc1_info;
 
     void       *eac3_priv;
+
+    MOVMuxCencContext cenc;
 } MOVTrack;
+
+typedef enum {
+    MOV_ENC_NONE = 0,
+    MOV_ENC_CENC_AES_CTR,
+} MOVEncryptionScheme;
 
 typedef struct MOVMuxContext {
     const AVClass *av_class;
@@ -193,6 +201,14 @@ typedef struct MOVMuxContext {
 
     int frag_interleave;
     int missing_duration_warned;
+
+    char *encryption_scheme_str;
+    MOVEncryptionScheme encryption_scheme;
+    uint8_t *encryption_key;
+    int encryption_key_len;
+    uint8_t *encryption_kid;
+    int encryption_kid_len;
+
 } MOVMuxContext;
 
 #define FF_MOV_FLAG_RTP_HINT              (1 <<  0)

--- a/libavformat/movenccenc.c
+++ b/libavformat/movenccenc.c
@@ -1,0 +1,411 @@
+/*
+ * MOV CENC (Common Encryption) writer
+ * Copyright (c) 2015 Eran Kornblau <erankor at gmail dot com>
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+#include "movenccenc.h"
+#include "libavutil/intreadwrite.h"
+#include "avio_internal.h"
+#include "movenc.h"
+#include "avc.h"
+
+static int auxiliary_info_alloc_size(MOVMuxCencContext* ctx, int size)
+{
+    size_t new_alloc_size;
+
+    if (ctx->auxiliary_info_size + size > ctx->auxiliary_info_alloc_size) {
+        new_alloc_size = FFMAX(ctx->auxiliary_info_size + size, ctx->auxiliary_info_alloc_size * 2);
+        if (av_reallocp(&ctx->auxiliary_info, new_alloc_size)) {
+            return AVERROR(ENOMEM);
+        }
+
+        ctx->auxiliary_info_alloc_size = new_alloc_size;
+    }
+
+    return 0;
+}
+
+static int auxiliary_info_write(MOVMuxCencContext* ctx,
+                                         const uint8_t *buf_in, int size)
+{
+    int ret;
+
+    ret = auxiliary_info_alloc_size(ctx, size);
+    if (ret) {
+        return ret;
+    }
+    memcpy(ctx->auxiliary_info + ctx->auxiliary_info_size, buf_in, size);
+    ctx->auxiliary_info_size += size;
+
+    return 0;
+}
+
+static int auxiliary_info_add_subsample(MOVMuxCencContext* ctx,
+    uint16_t clear_bytes, uint32_t encrypted_bytes)
+{
+    u_char* p;
+    int ret;
+
+    if (!ctx->use_subsamples) {
+        return 0;
+    }
+
+    ret = auxiliary_info_alloc_size(ctx, 6);
+    if (ret) {
+        return ret;
+    }
+
+    p = ctx->auxiliary_info + ctx->auxiliary_info_size;
+
+    AV_WB16(p, clear_bytes);
+    p += sizeof(uint16_t);
+
+    AV_WB32(p, encrypted_bytes);
+
+    ctx->auxiliary_info_size += 6;
+    ctx->subsample_count++;
+
+    return 0;
+}
+
+/**
+ * Encrypt the input buffer and write using avio_write
+ */
+static void mov_cenc_write_encrypted(MOVMuxCencContext* ctx, AVIOContext *pb,
+                                     const uint8_t *buf_in, int size)
+{
+    uint8_t chunk[4096];
+    const uint8_t* cur_pos = buf_in;
+    int size_left = size;
+    int cur_size;
+
+    while (size_left > 0) {
+        cur_size = FFMIN(size_left, sizeof(chunk));
+        av_aes_ctr_crypt(ctx->aes_ctr, chunk, cur_pos, cur_size);
+        avio_write(pb, chunk, cur_size);
+        cur_pos += cur_size;
+        size_left -= cur_size;
+    }
+}
+
+/**
+ * Start writing a packet
+ */
+static int mov_cenc_start_packet(MOVMuxCencContext* ctx)
+{
+    int ret;
+
+    /* write the iv */
+    ret = auxiliary_info_write(ctx, av_aes_ctr_get_iv(ctx->aes_ctr), AES_CTR_IV_SIZE);
+    if (ret) {
+        return ret;
+    }
+
+    if (!ctx->use_subsamples) {
+        return 0;
+    }
+
+    /* write a zero subsample count */
+    ctx->auxiliary_info_subsample_start = ctx->auxiliary_info_size;
+    ctx->subsample_count = 0;
+    ret = auxiliary_info_write(ctx, (uint8_t*)&ctx->subsample_count, sizeof(ctx->subsample_count));
+    if (ret) {
+        return ret;
+    }
+
+    return 0;
+}
+
+/**
+ * Finalize a packet
+ */
+static int mov_cenc_end_packet(MOVMuxCencContext* ctx)
+{
+    size_t new_alloc_size;
+
+    av_aes_ctr_increment_iv(ctx->aes_ctr);
+
+    if (!ctx->use_subsamples) {
+        ctx->auxiliary_info_entries++;
+        return 0;
+    }
+
+    /* add the auxiliary info entry size*/
+    if (ctx->auxiliary_info_entries >= ctx->auxiliary_info_sizes_alloc_size) {
+        new_alloc_size = ctx->auxiliary_info_entries * 2 + 1;
+        if (av_reallocp(&ctx->auxiliary_info_sizes, new_alloc_size)) {
+            return AVERROR(ENOMEM);
+        }
+
+        ctx->auxiliary_info_sizes_alloc_size = new_alloc_size;
+    }
+    ctx->auxiliary_info_sizes[ctx->auxiliary_info_entries] =
+        ctx->auxiliary_info_size - ctx->auxiliary_info_subsample_start;
+    ctx->auxiliary_info_entries++;
+
+    /* update the subsample count*/
+    AV_WB16(ctx->auxiliary_info + ctx->auxiliary_info_subsample_start, ctx->subsample_count);
+
+    return 0;
+}
+
+int ff_mov_cenc_write_packet(MOVMuxCencContext* ctx, AVIOContext *pb,
+                          const uint8_t *buf_in, int size)
+{
+    int ret;
+
+    ret = mov_cenc_start_packet(ctx);
+    if (ret) {
+        return ret;
+    }
+
+    ret = auxiliary_info_add_subsample(ctx, 0, size);
+    if (ret) {
+        return ret;
+    }
+
+    mov_cenc_write_encrypted(ctx, pb, buf_in, size);
+
+    ret = mov_cenc_end_packet(ctx);
+    if (ret) {
+        return ret;
+    }
+
+    return 0;
+}
+
+int ff_mov_cenc_avc_parse_nal_units(MOVMuxCencContext* ctx, AVIOContext *pb,
+                                 const uint8_t *buf_in, int size)
+{
+    const uint8_t *p = buf_in;
+    const uint8_t *end = p + size;
+    const uint8_t *nal_start, *nal_end;
+    int ret;
+
+    ret = mov_cenc_start_packet(ctx);
+    if (ret) {
+        return ret;
+    }
+
+    size = 0;
+    nal_start = ff_avc_find_startcode(p, end);
+    for (;;) {
+        while (nal_start < end && !*(nal_start++));
+        if (nal_start == end)
+            break;
+
+        nal_end = ff_avc_find_startcode(nal_start, end);
+
+        avio_wb32(pb, nal_end - nal_start);
+        avio_w8(pb, *nal_start);
+        mov_cenc_write_encrypted(ctx, pb, nal_start + 1, nal_end - nal_start - 1);
+
+        auxiliary_info_add_subsample(ctx, 5, nal_end - nal_start - 1);
+
+        size += 4 + nal_end - nal_start;
+        nal_start = nal_end;
+    }
+
+    ret = mov_cenc_end_packet(ctx);
+    if (ret) {
+        return ret;
+    }
+
+    return size;
+}
+
+int ff_mov_cenc_avc_write_nal_units(AVFormatContext *s, MOVMuxCencContext* ctx,
+    int nal_length_size, AVIOContext *pb, const uint8_t *buf_in, int size)
+{
+    int nalsize;
+    int ret;
+    int j;
+
+    ret = mov_cenc_start_packet(ctx);
+    if (ret) {
+        return ret;
+    }
+
+    while (size > 0) {
+        /* parse the nal size */
+        if (size < nal_length_size + 1) {
+            av_log(s, AV_LOG_ERROR, "CENC-AVC: remaining size %d smaller than nal length+type %d\n",
+                size, nal_length_size + 1);
+            return -1;
+        }
+
+        avio_write(pb, buf_in, nal_length_size + 1);
+
+        nalsize = 0;
+        for (j = 0; j < nal_length_size; j++) {
+            nalsize = (nalsize << 8) | *buf_in++;
+        }
+        size -= nal_length_size;
+
+        /* encrypt the nal body */
+        if (nalsize <= 0 || nalsize > size) {
+            av_log(s, AV_LOG_ERROR, "CENC-AVC: nal size %d remaining %d\n", nalsize, size);
+            return -1;
+        }
+
+        mov_cenc_write_encrypted(ctx, pb, buf_in + 1, nalsize - 1);
+        buf_in += nalsize;
+        size -= nalsize;
+
+        auxiliary_info_add_subsample(ctx, nal_length_size + 1, nalsize - 1);
+    }
+
+    ret = mov_cenc_end_packet(ctx);
+    if (ret) {
+        return ret;
+    }
+
+    return 0;
+}
+
+/* TODO: reuse this function from movenc.c */
+static int64_t update_size(AVIOContext *pb, int64_t pos)
+{
+    int64_t curpos = avio_tell(pb);
+    avio_seek(pb, pos, SEEK_SET);
+    avio_wb32(pb, curpos - pos); /* rewrite size */
+    avio_seek(pb, curpos, SEEK_SET);
+
+    return curpos - pos;
+}
+
+static int mov_cenc_write_senc_tag(MOVMuxCencContext* ctx, AVIOContext *pb,
+                                   int64_t* auxiliary_info_offset)
+{
+    int64_t pos = avio_tell(pb);
+
+    avio_wb32(pb, 0); /* size */
+    ffio_wfourcc(pb, "senc");
+    avio_wb32(pb, ctx->use_subsamples ? 0x02 : 0); /* version & flags */
+    avio_wb32(pb, ctx->auxiliary_info_entries); /* entry count */
+    *auxiliary_info_offset = avio_tell(pb);
+    avio_write(pb, ctx->auxiliary_info, ctx->auxiliary_info_size);
+    return update_size(pb, pos);
+}
+
+static int mov_cenc_write_saio_tag(AVIOContext *pb, int64_t auxiliary_info_offset)
+{
+    int64_t pos = avio_tell(pb);
+    uint8_t version;
+
+    avio_wb32(pb, 0); /* size */
+    ffio_wfourcc(pb, "saio");
+    version = auxiliary_info_offset > 0xffffffff ? 1 : 0;
+    avio_w8(pb, version);
+    avio_wb24(pb, 0); /* flags */
+    avio_wb32(pb, 1); /* entry count */
+    if (version) {
+        avio_wb64(pb, auxiliary_info_offset);
+    }
+    else {
+        avio_wb32(pb, auxiliary_info_offset);
+    }
+    return update_size(pb, pos);
+}
+
+static int mov_cenc_write_saiz_tag(MOVMuxCencContext* ctx, AVIOContext *pb)
+{
+    int64_t pos = avio_tell(pb);
+    avio_wb32(pb, 0); /* size */
+    ffio_wfourcc(pb, "saiz");
+    avio_wb32(pb, 0); /* version & flags */
+    avio_w8(pb, ctx->use_subsamples ? 0 : AES_CTR_IV_SIZE);    /* default size*/
+    avio_wb32(pb, ctx->auxiliary_info_entries); /* entry count */
+    if (ctx->use_subsamples) {
+        avio_write(pb, ctx->auxiliary_info_sizes, ctx->auxiliary_info_entries);
+    }
+    return update_size(pb, pos);
+}
+
+void ff_mov_cenc_write_stbl_atoms(MOVMuxCencContext* ctx, AVIOContext *pb)
+{
+    int64_t auxiliary_info_offset;
+
+    mov_cenc_write_senc_tag(ctx, pb, &auxiliary_info_offset);
+    mov_cenc_write_saio_tag(pb, auxiliary_info_offset);
+    mov_cenc_write_saiz_tag(ctx, pb);
+}
+
+static int mov_cenc_write_schi_tag(AVIOContext *pb, uint8_t* kid)
+{
+    int64_t pos = avio_tell(pb);
+    avio_wb32(pb, 0);     /* size */
+    ffio_wfourcc(pb, "schi");
+
+    avio_wb32(pb, 32);    /* size */
+    ffio_wfourcc(pb, "tenc");
+    avio_wb32(pb, 0);     /* version & flags */
+    avio_wb24(pb, 1);     /* is encrypted */
+    avio_w8(pb, AES_CTR_IV_SIZE); /* iv size */
+    avio_write(pb, kid, CENC_KID_SIZE);
+
+    return update_size(pb, pos);
+}
+
+int ff_mov_cenc_write_sinf_tag(MOVTrack* track, AVIOContext *pb, uint8_t* kid)
+{
+    int64_t pos = avio_tell(pb);
+    avio_wb32(pb, 0); /* size */
+    ffio_wfourcc(pb, "sinf");
+
+    /* frma */
+    avio_wb32(pb, 12);    /* size */
+    ffio_wfourcc(pb, "frma");
+    avio_wl32(pb, track->tag);
+
+    /* schm */
+    avio_wb32(pb, 20);    /* size */
+    ffio_wfourcc(pb, "schm");
+    avio_wb32(pb, 0); /* version & flags */
+    ffio_wfourcc(pb, "cenc");    /* scheme type*/
+    avio_wb32(pb, 0x10000); /* scheme version */
+
+    /* schi */
+    mov_cenc_write_schi_tag(pb, kid);
+
+    return update_size(pb, pos);
+}
+
+int ff_mov_cenc_init(MOVMuxCencContext* ctx, uint8_t* encryption_key, int use_subsamples)
+{
+    int ret;
+
+    ctx->aes_ctr = av_aes_ctr_alloc();
+    if (!ctx->aes_ctr) {
+        return AVERROR(ENOMEM);
+    }
+
+    ret = av_aes_ctr_init(ctx->aes_ctr, encryption_key, NULL);
+    if (ret != 0) {
+        return ret;
+    }
+
+    ctx->use_subsamples = use_subsamples;
+
+    return 0;
+}
+
+void ff_mov_cenc_free(MOVMuxCencContext* ctx)
+{
+    av_aes_ctr_free(ctx->aes_ctr);
+}

--- a/libavformat/movenccenc.h
+++ b/libavformat/movenccenc.h
@@ -1,0 +1,86 @@
+/*
+ * MOV CENC (Common Encryption) writer
+ * Copyright (c) 2015 Eran Kornblau <erankor at gmail dot com>
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef AVFORMAT_MOVENCCENC_H
+#define AVFORMAT_MOVENCCENC_H
+
+#include "libavutil/aes_ctr.h"
+#include "avformat.h"
+#include "avio.h"
+
+#define CENC_KID_SIZE (16)
+
+struct MOVTrack;
+
+typedef struct {
+    struct AVAESCTR* aes_ctr;
+    uint8_t* auxiliary_info;
+    size_t auxiliary_info_size;
+    size_t auxiliary_info_alloc_size;
+    uint32_t auxiliary_info_entries;
+
+    /* subsample support */
+    int use_subsamples;
+    uint16_t subsample_count;
+    size_t auxiliary_info_subsample_start;
+    uint8_t* auxiliary_info_sizes;
+    size_t  auxiliary_info_sizes_alloc_size;
+} MOVMuxCencContext;
+
+/**
+ * Initialize a CENC context
+ * @param key encryption key, must have a length of AES_CTR_KEY_SIZE
+ * @param use_subsamples when enabled parts of a packet can be encrypted, otherwise the whole packet is encrypted
+ */
+int ff_mov_cenc_init(MOVMuxCencContext* ctx, uint8_t* encryption_key, int use_subsamples);
+
+/**
+ * Free a CENC context
+ */
+void ff_mov_cenc_free(MOVMuxCencContext* ctx);
+
+/**
+ * Write a fully encrypted packet
+ */
+int ff_mov_cenc_write_packet(MOVMuxCencContext* ctx, AVIOContext *pb, const uint8_t *buf_in, int size);
+
+/**
+ * Parse AVC NAL units from annex B format, the nal size and type are written in the clear while the body is encrypted
+ */
+int ff_mov_cenc_avc_parse_nal_units(MOVMuxCencContext* ctx, AVIOContext *pb, const uint8_t *buf_in, int size);
+
+/**
+ * Write AVC NAL units that are in MP4 format, the nal size and type are written in the clear while the body is encrypted
+ */
+int ff_mov_cenc_avc_write_nal_units(AVFormatContext *s, MOVMuxCencContext* ctx, int nal_length_size,
+    AVIOContext *pb, const uint8_t *buf_in, int size);
+
+/**
+ * Write the cenc atoms that should reside inside stbl
+ */
+void ff_mov_cenc_write_stbl_atoms(MOVMuxCencContext* ctx, AVIOContext *pb);
+
+/**
+ * Write the sinf atom, contained inside stsd
+ */
+int ff_mov_cenc_write_sinf_tag(struct MOVTrack* track, AVIOContext *pb, uint8_t* kid);
+
+#endif /* AVFORMAT_MOVENCCENC_H */

--- a/libavutil/Makefile
+++ b/libavutil/Makefile
@@ -4,6 +4,7 @@ NAME = avutil
 
 HEADERS = adler32.h                                                     \
           aes.h                                                         \
+          aes_ctr.h                                                     \
           attributes.h                                                  \
           audio_fifo.h                                                  \
           avassert.h                                                    \
@@ -80,6 +81,7 @@ BUILT_HEADERS = avconfig.h                                              \
 
 OBJS = adler32.o                                                        \
        aes.o                                                            \
+       aes_ctr.o                                                        \
        audio_fifo.o                                                     \
        avstring.o                                                       \
        base64.o                                                         \

--- a/libavutil/aes_ctr.c
+++ b/libavutil/aes_ctr.c
@@ -1,0 +1,133 @@
+/*
+ * AES-CTR cipher
+ * Copyright (c) 2015 Eran Kornblau <erankor at gmail dot com>
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "common.h"
+#include "aes_ctr.h"
+#include "aes.h"
+#include "random_seed.h"
+
+#define AES_BLOCK_SIZE (16)
+
+typedef struct AVAESCTR {
+    struct AVAES* aes;
+    uint8_t counter[AES_BLOCK_SIZE];
+    uint8_t encrypted_counter[AES_BLOCK_SIZE];
+    int block_offset;
+} AVAESCTR;
+
+struct AVAESCTR *av_aes_ctr_alloc(void)
+{
+    return av_mallocz(sizeof(struct AVAESCTR));
+}
+
+void av_aes_ctr_set_iv(struct AVAESCTR *a, const uint8_t* iv)
+{
+    memcpy(a->counter, iv, AES_CTR_IV_SIZE);
+    memset(a->counter + AES_CTR_IV_SIZE, 0, sizeof(a->counter) - AES_CTR_IV_SIZE);
+    a->block_offset = 0;
+}
+
+const uint8_t* av_aes_ctr_get_iv(struct AVAESCTR *a)
+{
+    return a->counter;
+}
+
+static void av_aes_ctr_set_random_iv(struct AVAESCTR *a)
+{
+    uint32_t iv[2];
+
+    iv[0] = av_get_random_seed();
+    iv[1] = av_get_random_seed();
+
+    av_aes_ctr_set_iv(a, (uint8_t*)iv);
+}
+
+int av_aes_ctr_init(struct AVAESCTR *a, const uint8_t *key, const uint8_t *iv)
+{
+    a->aes = av_aes_alloc();
+    if (!a->aes) {
+        return AVERROR(ENOMEM);
+    }
+
+    av_aes_init(a->aes, key, 128, 0);
+
+    if (iv) {
+        av_aes_ctr_set_iv(a, iv);
+    }
+    else {
+        av_aes_ctr_set_random_iv(a);
+    }
+
+    return 0;
+}
+
+void av_aes_ctr_free(struct AVAESCTR *a)
+{
+    if (a) {
+        av_freep(&a->aes);
+        av_freep(a);
+    }
+}
+
+static void av_aes_ctr_increment_be64(uint8_t* counter)
+{
+    uint8_t* cur_pos;
+
+    for (cur_pos = counter + 7; cur_pos >= counter; cur_pos--) {
+        (*cur_pos)++;
+        if (*cur_pos != 0) {
+            break;
+        }
+    }
+}
+
+void av_aes_ctr_increment_iv(struct AVAESCTR *a)
+{
+    av_aes_ctr_increment_be64(a->counter);
+    memset(a->counter + AES_CTR_IV_SIZE, 0, sizeof(a->counter) - AES_CTR_IV_SIZE);
+    a->block_offset = 0;
+}
+
+void av_aes_ctr_crypt(struct AVAESCTR *a, uint8_t *dst, const uint8_t *src, int count)
+{
+    const uint8_t* src_end = src + count;
+    const uint8_t* cur_end_pos;
+    uint8_t* encrypted_counter_pos;
+
+    while (src < src_end) {
+        if (a->block_offset == 0) {
+            av_aes_crypt(a->aes, a->encrypted_counter, a->counter, 1, NULL, 0);
+
+            av_aes_ctr_increment_be64(a->counter + 8);
+        }
+
+        encrypted_counter_pos = a->encrypted_counter + a->block_offset;
+        cur_end_pos = src + AES_BLOCK_SIZE - a->block_offset;
+        cur_end_pos = FFMIN(cur_end_pos, src_end);
+
+        a->block_offset += cur_end_pos - src;
+        a->block_offset &= (AES_BLOCK_SIZE - 1);
+
+        while (src < cur_end_pos) {
+            *dst++ = *src++ ^ *encrypted_counter_pos++;
+        }
+    }
+}

--- a/libavutil/aes_ctr.h
+++ b/libavutil/aes_ctr.h
@@ -1,0 +1,79 @@
+/*
+ * AES-CTR cipher
+ * Copyright (c) 2015 Eran Kornblau <erankor at gmail dot com>
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef AVUTIL_AES_CTR_H
+#define AVUTIL_AES_CTR_H
+
+#include <stdint.h>
+
+#include "attributes.h"
+#include "version.h"
+
+#define AES_CTR_KEY_SIZE (16)
+#define AES_CTR_IV_SIZE (8)
+
+struct AVAESCTR;
+
+/**
+ * Allocate an AVAESCTR context.
+ */
+struct AVAESCTR *av_aes_ctr_alloc(void);
+
+/**
+ * Initialize an AVAESCTR context.
+ * @param key encryption key, must have a length of AES_CTR_KEY_SIZE
+ * @param iv encryption iv, must have a length of AES_CTR_IV_SIZE, if not set a random iv will be used
+ */
+int av_aes_ctr_init(struct AVAESCTR *a, const uint8_t *key, const uint8_t *iv);
+
+/**
+ * Release an AVAESCTR context.
+ */
+void av_aes_ctr_free(struct AVAESCTR *a);
+
+/**
+ * Process a buffer using a previously initialized context.
+ * @param dst destination array, can be equal to src
+ * @param src source array, can be equal to dst
+ * @param size the size of src and dst
+ */
+void av_aes_ctr_crypt(struct AVAESCTR *a, uint8_t *dst, const uint8_t *src, int size);
+
+/**
+ * Get the current iv
+ */
+const uint8_t* av_aes_ctr_get_iv(struct AVAESCTR *a);
+
+/**
+ * Forcefully change the iv
+ */
+void av_aes_ctr_set_iv(struct AVAESCTR *a, const uint8_t* iv);
+
+/**
+ * Increment the top 64 bit of the iv (performed after each frame)
+ */
+void av_aes_ctr_increment_iv(struct AVAESCTR *a);
+
+/**
+ * @}
+ */
+
+#endif /* AVUTIL_AES_CTR_H */


### PR DESCRIPTION
support writing encrypted mp4 using aes-ctr, conforming to ISO/IEC
23001-7.

3 new parameters were added:
- encryption_scheme - allowed values are none (default) and cenc-aes-ctr
- encryption_key - 128 bit encryption key (hex)
- encryption_kid - 128 bit encryption key identifier (hex)