### PR TITLE
Refactoring conditional directives that break parts of statements.

### DIFF
--- a/libswscale/utils.c
+++ b/libswscale/utils.c
@@ -1555,10 +1555,11 @@ av_cold int sws_init_context(SwsContext *c, SwsFilter *srcFilter,
 #endif
 
 #ifdef MAP_ANONYMOUS
-            if (c->lumMmxextFilterCode == MAP_FAILED || c->chrMmxextFilterCode == MAP_FAILED)
+            int filterCodeTest = c->lumMmxextFilterCode == MAP_FAILED || c->chrMmxextFilterCode == MAP_FAILED;
 #else
-            if (!c->lumMmxextFilterCode || !c->chrMmxextFilterCode)
+            int filterCodeTest = !c->lumMmxextFilterCode || !c->chrMmxextFilterCode;
 #endif
+            if (filterCodeTest)
             {
                 av_log(c, AV_LOG_ERROR, "Failed to allocate MMX2FilterCode\n");
                 return AVERROR(ENOMEM);


### PR DESCRIPTION
   A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

    https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
    https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/

It might improve code understanding, maintainability and error-proneness.