### PR TITLE
Update xmv.c

### DIFF
--- a/libavformat/xmv.c
+++ b/libavformat/xmv.c
@@ -573,6 +573,7 @@ static int xmv_read_packet(AVFormatContext *s,
 AVInputFormat ff_xmv_demuxer = {
     .name           = "xmv",
     .long_name      = NULL_IF_CONFIG_SMALL("Microsoft XMV"),
+    .extensions     = "xmv",
     .priv_data_size = sizeof(XMVDemuxContext),
     .read_probe     = xmv_probe,
     .read_header    = xmv_read_header,


### PR DESCRIPTION
Add *.xmv to the recognized filename extensions for the XMV format. There are many .xmv files floating around. Without this change, av_guess_format(NULL, "myvideo.xmv", NULL) would return a null even though the file is supported.