### PR TITLE
avfilter/src_movie: fix how we check for overflows with seek_point

### DIFF
--- a/libavfilter/src_movie.c
+++ b/libavfilter/src_movie.c
@@ -240,7 +240,7 @@ static av_cold int movie_common_init(AVFilterContext *ctx)
         timestamp = movie->seek_point;
         // add the stream start time, should it exist
         if (movie->format_ctx->start_time != AV_NOPTS_VALUE) {
-            if (timestamp > INT64_MAX - movie->format_ctx->start_time) {
+            if (timestamp > 0 && movie->format_ctx->start_time > INT64_MAX - timestamp) {
                 av_log(ctx, AV_LOG_ERROR,
                        "%s: seek value overflow with start_time:%"PRId64" seek_point:%"PRId64"\n",
                        movie->file_name, movie->format_ctx->start_time, movie->seek_point);


### PR DESCRIPTION
When the movie source filter is used and a seek_point is specified, we have to add to that point the stream start time. Before we do that, we have to check if the addition overflows. Currently, that check is done incorrectly: to check that `a + b` overflows, it is not enought to do `a > INT64_MAX - b` because `b` might be negative; the correct way is `b > 0 && a > INT64_MAX - b`.