### PR TITLE
[BUG]fix a dca bug which will cause data undecoded lost

### DIFF
--- a/libavcodec/dcadec.c
+++ b/libavcodec/dcadec.c
@@ -1990,7 +1990,9 @@ static int dca_decode_frame(AVCodecContext *avctx, void *data,
         avctx->bit_rate = s->bit_rate;
     *got_frame_ptr = 1;
 
-    return buf_size;
+    //fixed by chenhaixin
+    //    return buf_size;
+    return FFMIN(buf_size, s->frame_size);
 }
 
 /**


### PR DESCRIPTION
if the undecoded data is left, such as the incoming dts is more than one frame, this bug will cause a data lost of the undecoded data