### PR TITLE
[TRIVIAL BUG FIX] libavdevice/decklink_common.h: fix broken build due to missing `/`

### DIFF
--- a/libavdevice/decklink_common.h
+++ b/libavdevice/decklink_common.h
@@ -106,4 +106,4 @@ int ff_decklink_set_format(AVFormatContext *avctx, decklink_direction_t directio
 int ff_decklink_list_devices(AVFormatContext *avctx);
 int ff_decklink_list_formats(AVFormatContext *avctx, decklink_direction_t direction = DIRECTION_OUT);
 
-#endif /* AVDEVICE_DECKLINK_COMMON_H *
+#endif /* AVDEVICE_DECKLINK_COMMON_H */


### PR DESCRIPTION
The build in the master branch is currently broken due to a missing
`/` in a comment introduced by commit
44304ae3220f553d0b1458644e2a617ea1ad8d22 - `all: Add missing header guards`

@TimothyGu , Please merge my fix.

note: this was also sent to ffmpeg-devel: http://ffmpeg.org/pipermail/ffmpeg-devel/2016-January/188275.html