### PR TITLE
RTCP synchronization packet was broken

### DIFF
--- a/libavformat/rtpenc.c
+++ b/libavformat/rtpenc.c
@@ -271,7 +271,8 @@ static void rtcp_send_sr(AVFormatContext *s1, int64_t ntp_time, int bye)
     avio_w8(s1->pb, RTCP_SR);
     avio_wb16(s1->pb, 6); /* length in words - 1 */
     avio_wb32(s1->pb, s->ssrc);
-    avio_wb64(s1->pb, NTP_TO_RTP_FORMAT(ntp_time));
+    avio_wb32(s1->pb, ntp_time / 1000000);
+    avio_wb32(s1->pb, ((ntp_time % 1000000) << 32) / 1000000);
     avio_wb32(s1->pb, rtp_ts);
     avio_wb32(s1->pb, s->packet_count);
     avio_wb32(s1->pb, s->octet_count);


### PR DESCRIPTION
RTCP synchronization packet was broken since commit in ffmpeg version > 2.8.3:
```
e04b039b1528f4c7df5c2b93865651bfea168a19
   avutil/mathematics: return INT64_MIN (=AV_NOPTS_VALUE) from av_rescale_rnd() for overflows
```

Since this commit: 
```
2e814d0329aded98c811d0502839618f08642685
  rtpenc: Simplify code by introducing a macro for rescaling NTP timestamps

-    avio_wb32(s1->pb, ntp_time / 1000000);
-    avio_wb32(s1->pb, ((ntp_time % 1000000) << 32) / 1000000);
+    avio_wb64(s1->pb, NTP_TO_RTP_FORMAT(ntp_time));
```

NTP_TO_RTP_FORMAT uses av_rescale_rnd() function to add the data to the packet. This causes
an overflow in the av_rescale_rnd() function and it will use this part:

```
       if (t1 > INT64_MAX)
            return INT64_MIN;
```
Causing the NTP stamp to have an invalid value.

Reverting commit '2e814d0329aded98c811d0502839618f08642685' solves the problem.