### PR TITLE
fix: the "delete-segment" flag did not work properly

### DIFF
--- a/libavformat/hlsenc.c
+++ b/libavformat/hlsenc.c
@@ -127,12 +127,17 @@ static int hls_delete_old_segments(HLSContext *hls) {
     char *dirname = NULL, *p, *sub_path;
     char *path = NULL;
 
+	// Calculate the maximum playlist duration.
+	playlist_duration = hls->max_nb_segments * hls->time;
+
+	// Compensate for the segments that are currently in the playlist.
     segment = hls->segments;
     while (segment) {
-        playlist_duration += segment->duration;
+        playlist_duration -= segment->duration;
         segment = segment->next;
     }
 
+	// Check the old-segments.
     segment = hls->old_segments;
     while (segment) {
         playlist_duration -= segment->duration;


### PR DESCRIPTION
fix: the "delete-segment" flag did not work properly (implementation in commit 97b65f6). The set length of the list was populated twice (e.g. setting the list-size to 10, creates a list of approx. 20 files). Now calculation works on the theoretical playlist length compensated for the segment lengths that are currently in the playlist.