### PR TITLE
Making av_register_all() thread-safe.

### DIFF
--- a/libavformat/allformats.c
+++ b/libavformat/allformats.c
@@ -47,8 +47,7 @@ void av_register_all(void)
 
     if (initialized)
         return;
-    initialized = 1;
-
+    
     avcodec_register_all();
 
     /* (de)muxers */
@@ -367,4 +366,6 @@ void av_register_all(void)
     REGISTER_DEMUXER (LIBGME,           libgme);
     REGISTER_DEMUXER (LIBMODPLUG,       libmodplug);
     REGISTER_MUXDEMUX(LIBNUT,           libnut);
+    
+    initialized = 1;
 }


### PR DESCRIPTION
When multiple threads tries to call av_register_all(), the first thread sets initialized to 1 and do the register process. At the same time, other thread might also call av_register_all(), which returns immediately because initialized is set to 1 (even when it has not completed registering codecs). We can avoid this problem if we set initialised to 1 while exiting from function.