### PR TITLE
Update configure to better support OS/2

### DIFF
--- a/configure
+++ b/configure
@@ -5881,7 +5881,10 @@ check_cflags -Wdeclaration-after-statement
 check_cflags -Wall
 check_cflags -Wdisabled-optimization
 check_cflags -Wpointer-arith
-check_cflags -Wredundant-decls
+if test "$host_os" != "os/2"; then
+    # This causes too much noise in libc headers on OS/2
+    check_cflags -Wredundant-decls
+fi
 check_cflags -Wwrite-strings
 check_cflags -Wtype-limits
 check_cflags -Wundef

--- a/configure
+++ b/configure
@@ -734,7 +734,12 @@ check_deps(){
 
 print_config(){
     pfx=$1
-    files=$2
+    if test "$host_os" = "os/2"; then
+        # awk treats \ as escape chars, convert them to / in paths
+        files=`echo "$2" | tr '\\\' /`
+    else
+        files=$2
+    fi
     shift 2
     map 'eval echo "$v \${$v:-no}"' "$@" |
     awk "BEGIN { split(\"$files\", files) }
@@ -3550,10 +3555,10 @@ fi
 
 tmpfile(){
     tmp=$(mktemp -u "${TMPDIR}/ffconf.XXXXXXXX")$2 &&
-        (set -C; exec > $tmp) 2>/dev/null ||
+        (set -C; exec > "$tmp") 2>/dev/null ||
         die "Unable to create temporary file in $TMPDIR."
-    append TMPFILES $tmp
-    eval $1=$tmp
+    append TMPFILES "$tmp"
+    eval $1=\"$tmp\"
 }
 
 trap 'rm -f -- $TMPFILES' EXIT

--- a/configure
+++ b/configure
@@ -4716,7 +4716,6 @@ case $target_os in
         ;;
     os/2*)
         strip="lxlite -CS"
-        ln_s="cp -f"
         objformat="aout"
         add_cppflags -D_GNU_SOURCE
         add_ldflags -Zomf -Zbin-files -Zargs-wild -Zmap
@@ -4724,16 +4723,18 @@ case $target_os in
         LIBSUF="_s.a"
         SLIBPREF=""
         SLIBSUF=".dll"
-        SLIBNAME_WITH_VERSION='$(SLIBPREF)$(NAME)-$(LIBVERSION)$(SLIBSUF)'
-        SLIBNAME_WITH_MAJOR='$(SLIBPREF)$(shell echo $(NAME) | cut -c1-6)$(LIBMAJOR)$(SLIBSUF)'
-        SLIB_CREATE_DEF_CMD='echo LIBRARY $(SLIBNAME_WITH_MAJOR) INITINSTANCE TERMINSTANCE > $(SUBDIR)$(NAME).def; \
-            echo CODE PRELOAD MOVEABLE DISCARDABLE >> $(SUBDIR)$(NAME).def; \
-            echo DATA PRELOAD MOVEABLE MULTIPLE NONSHARED >> $(SUBDIR)$(NAME).def; \
-            echo EXPORTS >> $(SUBDIR)$(NAME).def; \
-            emxexp $(OBJS) >> $(SUBDIR)$(NAME).def'
-        SLIB_EXTRA_CMD='emximp -o $(SUBDIR)$(LIBPREF)$(NAME)_dll.a $(SUBDIR)$(NAME).def; \
-            emximp -o $(SUBDIR)$(LIBPREF)$(NAME)_dll.lib $(SUBDIR)$(NAME).def;'
-        SLIB_INSTALL_EXTRA_LIB='$(LIBPREF)$(NAME)_dll.a $(LIBPREF)$(NAME)_dll.lib'
+        SLIBNAME_WITH_VERSION='$(SLIBPREF)$(FULLNAME)-$(LIBVERSION)$(SLIBSUF)'
+        SLIBNAME_WITH_MAJOR='$(SLIBPREF)$(shell echo $(FULLNAME) | cut -c1-6)$(LIBMAJOR)$(SLIBSUF)'
+        SLIB_CREATE_DEF_CMD='echo LIBRARY $(SLIBNAME_WITH_MAJOR:$(SLIBSUF)=) INITINSTANCE TERMINSTANCE > $(SUBDIR)$(FULLNAME).def; \
+            echo CODE PRELOAD MOVEABLE DISCARDABLE >> $(SUBDIR)$(FULLNAME).def; \
+            echo DATA PRELOAD MOVEABLE MULTIPLE NONSHARED >> $(SUBDIR)$(FULLNAME).def; \
+            echo EXPORTS >> $(SUBDIR)$(FULLNAME).def; \
+            emxexp $(OBJS) >> $(SUBDIR)$(FULLNAME).def'
+        SLIB_EXTRA_CMD='emximp -o $(SUBDIR)$(LIBPREF)$(FULLNAME)_dll.a $(SUBDIR)$(FULLNAME).def; \
+            emximp -o $(SUBDIR)$(LIBPREF)$(FULLNAME)_dll.lib $(SUBDIR)$(FULLNAME).def;'
+        SLIB_INSTALL_NAME='$(SLIBNAME_WITH_MAJOR)'
+        SLIB_INSTALL_LINKS=
+        SLIB_INSTALL_EXTRA_LIB='$(LIBPREF)$(FULLNAME)_dll.a $(LIBPREF)$(FULLNAME)_dll.lib'
         enable dos_paths
         enable_weak os2threads
         ;;


### PR DESCRIPTION
This set of patches addresses several issues of `configure` when run on OS/2. The commit messages should be self-descriptive. This also needs to be back-ported to releases/2.8 (as this is what e.g. Firefox 38 needs).