### PR TITLE
avfilter/transpose: fixed single thread mode

### DIFF
--- a/libavfilter/vf_transpose.c
+++ b/libavfilter/vf_transpose.c
@@ -250,7 +250,7 @@ static int filter_frame(AVFilterLink *inlink, AVFrame *in)
     }
 
     td.in = in, td.out = out;
-    ctx->internal->execute(ctx, filter_slice, &td, NULL, FFMIN(outlink->h, ctx->graph->nb_threads));
+    ctx->internal->execute(ctx, filter_slice, &td, NULL, FFMIN(outlink->h, ctx->graph->nb_threads ? ctx->graph->nb_threads : 1));
     av_frame_free(&in);
     return ff_filter_frame(outlink, out);
 }


### PR DESCRIPTION
This patch fixes code, just like bellow:
m_filter_graph = avfilter_graph_alloc();
m_filter_graph->thread_type = 0;