### PR TITLE
libavdevice/decklink: advanced options for selecting an input connection

### DIFF
--- a/libavdevice/decklink_common.h
+++ b/libavdevice/decklink_common.h
@@ -75,6 +75,8 @@ struct decklink_ctx {
     /* Options */
     int list_devices;
     int list_formats;
+    int list_vinputs;
+    int list_ainputs;
     int64_t teletext_lines;
     double preroll;
 
@@ -84,6 +86,11 @@ struct decklink_ctx {
     sem_t semaphore;
 
     int channels;
+};
+
+struct decklink_input_connection {
+    const char *name;
+    int64_t bitmask;
 };
 
 typedef enum { DIRECTION_IN, DIRECTION_OUT} decklink_direction_t;
@@ -105,5 +112,9 @@ int ff_decklink_set_format(AVFormatContext *avctx, int width, int height, int tb
 int ff_decklink_set_format(AVFormatContext *avctx, decklink_direction_t direction, int num);
 int ff_decklink_list_devices(AVFormatContext *avctx);
 int ff_decklink_list_formats(AVFormatContext *avctx, decklink_direction_t direction = DIRECTION_OUT);
+int ff_decklink_list_vinputs(AVFormatContext *avctx);
+int ff_decklink_list_ainputs(AVFormatContext *avctx);
+int ff_decklink_set_vinput(AVFormatContext *avctx, int connection);
+int ff_decklink_set_ainput(AVFormatContext *avctx, int connection);
 
 #endif /* AVDEVICE_DECKLINK_COMMON_H */

--- a/libavdevice/decklink_common_c.h
+++ b/libavdevice/decklink_common_c.h
@@ -30,6 +30,8 @@ struct decklink_cctx {
     /* Options */
     int list_devices;
     int list_formats;
+    int list_vinputs;
+    int list_ainputs;
     int64_t teletext_lines;
     double preroll;
     int v210;

--- a/libavdevice/decklink_dec_c.c
+++ b/libavdevice/decklink_dec_c.c
@@ -31,6 +31,8 @@
 static const AVOption options[] = {
     { "list_devices", "list available devices"  , OFFSET(list_devices), AV_OPT_TYPE_INT   , { .i64 = 0   }, 0, 1, DEC },
     { "list_formats", "list supported formats"  , OFFSET(list_formats), AV_OPT_TYPE_INT   , { .i64 = 0   }, 0, 1, DEC },
+    { "list_vinputs", "list video inputs"  ,      OFFSET(list_vinputs), AV_OPT_TYPE_INT   , { .i64 = 0   }, 0, 1, DEC },
+    { "list_ainputs", "list audio inputs"  ,      OFFSET(list_ainputs), AV_OPT_TYPE_INT   , { .i64 = 0   }, 0, 1, DEC },
     { "bm_v210",      "v210 10 bit per channel" , OFFSET(v210),         AV_OPT_TYPE_INT   , { .i64 = 0   }, 0, 1, DEC },
     { "teletext_lines", "teletext lines bitmask", OFFSET(teletext_lines), AV_OPT_TYPE_INT64, { .i64 = 0   }, 0, 0x7ffffffffLL, DEC, "teletext_lines"},
     { "standard",     NULL,                                           0,  AV_OPT_TYPE_CONST, { .i64 = 0x7fff9fffeLL}, 0, 0,    DEC, "teletext_lines"},


### PR DESCRIPTION
This patch add additional input options: video input connection (vinput), audio input connection (ainput).

Usage:
     ffmpeg -f decklink -i 'Card name'@fmt:vinput:ainput
Where fmt, vinput and ainput are optional

Also it adds list_vinputs and list_ainputs