### PR TITLE
fix memory leak in url_find_protocol

### DIFF
--- a/libavformat/avio.c
+++ b/libavformat/avio.c
@@ -282,7 +282,7 @@ static const struct URLProtocol *url_find_protocol(const char *filename)
             return up;
         }
     }
-
+    av_freep(&protocols);
     return NULL;
 }
 


### PR DESCRIPTION
When proto_str is not found in the for loop, there will be a memory leak malloec in ffurl-get_rpotocols().