### PR TITLE
Timeline function to the eq filter

### DIFF
--- a/libavfilter/vf_eq.c
+++ b/libavfilter/vf_eq.c
@@ -385,4 +385,5 @@ AVFilter ff_vf_eq = {
     .query_formats   = query_formats,
     .init            = initialize,
     .uninit          = uninit,
+    .flags         = AVFILTER_FLAG_SUPPORT_TIMELINE_GENERIC,
 };


### PR DESCRIPTION
Now it is possible to use eq=enable='between(t\,a\,b)' functionality.