### PR TITLE
Mov skip nonkey

### DIFF
--- a/libavformat/mov.c
+++ b/libavformat/mov.c
@@ -5217,7 +5217,7 @@ static int mov_read_packet(AVFormatContext *s, AVPacket *pkt)
         }
 
         if( st->discard == AVDISCARD_NONKEY && 0==(sample->flags & AVINDEX_KEYFRAME) ) {
-            av_log(mov->fc, AV_LOG_, "Nonkey frame from stream %d discarded due to AVDISCARD_NONKEY\n");
+            av_log(mov->fc, AV_LOG_DEBUG, "Nonkey frame from stream %d discarded due to AVDISCARD_NONKEY\n", sc->ffindex);
             goto retry;
         }
 

--- a/libavformat/mov.c
+++ b/libavformat/mov.c
@@ -5215,6 +5215,12 @@ static int mov_read_packet(AVFormatContext *s, AVPacket *pkt)
             sc->current_sample -= should_retry(sc->pb, ret64);
             return AVERROR_INVALIDDATA;
         }
+
+        if( st->discard == AVDISCARD_NONKEY && 0==(sample->flags & AVINDEX_KEYFRAME) ) {
+            av_log(mov->fc, AV_LOG_, "Nonkey frame from stream %d discarded due to AVDISCARD_NONKEY\n");
+            goto retry;
+        }
+
         ret = av_get_packet(sc->pb, pkt, sample->size);
         if (ret < 0) {
             sc->current_sample -= should_retry(sc->pb, ret);


### PR DESCRIPTION
Mov demuxer skips non-key frames if AVDISCARD_NONKEY is set.