### PR TITLE
Update omx.c - gop paramater

### DIFF
--- a/libavcodec/omx.c
+++ b/libavcodec/omx.c
@@ -522,7 +522,7 @@ static av_cold int omx_component_init(AVCodecContext *avctx, const char *role)
         err = OMX_GetParameter(s->handle, OMX_IndexParamVideoAvc, &avc);
         CHECK(err);
         avc.nBFrames = 0;
-        avc.nPFrames = avctx->gop_size - 1;
+        avc.nPFrames = avctx->gop_size;
         err = OMX_SetParameter(s->handle, OMX_IndexParamVideoAvc, &avc);
         CHECK(err);
     }


### PR DESCRIPTION
Remove  - 1 at avc.nPFrames = avctx->gop_size;

Currently the gop will drift from that defined at the command line due to the -1. Having removed and tested the gop stays constant after it's removal.
