### PR TITLE
removing "," to fix pedantic warning

### DIFF
--- a/libavutil/avutil.h
+++ b/libavutil/avutil.h
@@ -271,7 +271,7 @@ enum AVPictureType {
     AV_PICTURE_TYPE_S,     ///< S(GMC)-VOP MPEG-4
     AV_PICTURE_TYPE_SI,    ///< Switching Intra
     AV_PICTURE_TYPE_SP,    ///< Switching Predicted
-    AV_PICTURE_TYPE_BI,    ///< BI type
+    AV_PICTURE_TYPE_BI     ///< BI type
 };
 
 /**

--- a/libavutil/frame.h
+++ b/libavutil/frame.h
@@ -130,7 +130,7 @@ enum AVActiveFormatDescription {
     AV_AFD_14_9         = 11,
     AV_AFD_4_3_SP_14_9  = 13,
     AV_AFD_16_9_SP_14_9 = 14,
-    AV_AFD_SP_4_3       = 15,
+    AV_AFD_SP_4_3       = 15
 };
 
 

--- a/libavutil/log.h
+++ b/libavutil/log.h
@@ -44,7 +44,7 @@ typedef enum {
     AV_CLASS_CATEGORY_DEVICE_AUDIO_INPUT,
     AV_CLASS_CATEGORY_DEVICE_OUTPUT,
     AV_CLASS_CATEGORY_DEVICE_INPUT,
-    AV_CLASS_CATEGORY_NB, ///< not part of ABI/API
+    AV_CLASS_CATEGORY_NB ///< not part of ABI/API
 }AVClassCategory;
 
 #define AV_IS_INPUT_DEVICE(category) \

--- a/libavutil/mathematics.h
+++ b/libavutil/mathematics.h
@@ -105,7 +105,7 @@ enum AVRounding {
      * //     => AV_NOPTS_VALUE
      * @endcode
      */
-    AV_ROUND_PASS_MINMAX = 8192,
+    AV_ROUND_PASS_MINMAX = 8192
 };
 
 /**

--- a/libavutil/opt.h
+++ b/libavutil/opt.h
@@ -236,7 +236,7 @@ enum AVOptionType{
     AV_OPT_TYPE_DURATION   = MKBETAG('D','U','R',' '),
     AV_OPT_TYPE_COLOR      = MKBETAG('C','O','L','R'),
     AV_OPT_TYPE_CHANNEL_LAYOUT = MKBETAG('C','H','L','A'),
-    AV_OPT_TYPE_BOOL           = MKBETAG('B','O','O','L'),
+    AV_OPT_TYPE_BOOL           = MKBETAG('B','O','O','L')
 };
 
 /**

--- a/libavutil/pixfmt.h
+++ b/libavutil/pixfmt.h
@@ -306,7 +306,7 @@ enum AVPixelFormat {
 
     AV_PIX_FMT_MEDIACODEC, ///< hardware decoding through MediaCodec
 
-    AV_PIX_FMT_NB,        ///< number of pixel formats, DO NOT USE THIS if you want to link with shared libav* because the number of formats might differ between versions
+    AV_PIX_FMT_NB         ///< number of pixel formats, DO NOT USE THIS if you want to link with shared libav* because the number of formats might differ between versions
 };
 
 #if AV_HAVE_BIGENDIAN
@@ -401,7 +401,7 @@ enum AVColorPrimaries {
     AVCOL_PRI_SMPTEST428_1 = 10, ///< SMPTE ST 428-1 (CIE 1931 XYZ)
     AVCOL_PRI_SMPTE431    = 11, ///< SMPTE ST 431-2 (2011)
     AVCOL_PRI_SMPTE432    = 12, ///< SMPTE ST 432-1 D65 (2010)
-    AVCOL_PRI_NB,               ///< Not part of ABI
+    AVCOL_PRI_NB                ///< Not part of ABI
 };
 
 /**
@@ -427,7 +427,7 @@ enum AVColorTransferCharacteristic {
     AVCOL_TRC_SMPTEST2084  = 16, ///< SMPTE ST 2084 for 10-, 12-, 14- and 16-bit systems
     AVCOL_TRC_SMPTEST428_1 = 17, ///< SMPTE ST 428-1
     AVCOL_TRC_ARIB_STD_B67 = 18, ///< ARIB STD-B67, known as "Hybrid log-gamma"
-    AVCOL_TRC_NB,                ///< Not part of ABI
+    AVCOL_TRC_NB                 ///< Not part of ABI
 };
 
 /**
@@ -446,7 +446,7 @@ enum AVColorSpace {
     AVCOL_SPC_BT2020_NCL  = 9,  ///< ITU-R BT2020 non-constant luminance system
     AVCOL_SPC_BT2020_CL   = 10, ///< ITU-R BT2020 constant luminance system
     AVCOL_SPC_SMPTE2085   = 11, ///< SMPTE 2085, Y'D'zD'x
-    AVCOL_SPC_NB,               ///< Not part of ABI
+    AVCOL_SPC_NB                ///< Not part of ABI
 };
 #define AVCOL_SPC_YCGCO AVCOL_SPC_YCOCG
 
@@ -458,7 +458,7 @@ enum AVColorRange {
     AVCOL_RANGE_UNSPECIFIED = 0,
     AVCOL_RANGE_MPEG        = 1, ///< the normal 219*2^(n-8) "MPEG" YUV ranges
     AVCOL_RANGE_JPEG        = 2, ///< the normal     2^n-1   "JPEG" YUV ranges
-    AVCOL_RANGE_NB,              ///< Not part of ABI
+    AVCOL_RANGE_NB               ///< Not part of ABI
 };
 
 /**
@@ -484,7 +484,7 @@ enum AVChromaLocation {
     AVCHROMA_LOC_TOP         = 4,
     AVCHROMA_LOC_BOTTOMLEFT  = 5,
     AVCHROMA_LOC_BOTTOM      = 6,
-    AVCHROMA_LOC_NB,              ///< Not part of ABI
+    AVCHROMA_LOC_NB               ///< Not part of ABI
 };
 
 #endif /* AVUTIL_PIXFMT_H */


### PR DESCRIPTION
This fixes warnings when compiling against ffmpeg with gcc and pedantic warnings enabled. If this is of interest I can fix similar things in other header files as well.