### PR TITLE
Update for Chromaprint 1.4

### DIFF
--- a/libavformat/chromaprint.c
+++ b/libavformat/chromaprint.c
@@ -39,7 +39,11 @@ typedef struct ChromaprintMuxContext {
     int silence_threshold;
     int algorithm;
     FingerprintFormat fp_format;
+#if CPR_VERSION_INT >= AV_VERSION_INT(1, 4, 0)
+    ChromaprintContext * ctx;
+#else
     ChromaprintContext ctx;
+#endif
 } ChromaprintMuxContext;
 
 static void cleanup(ChromaprintMuxContext *cpr)


### PR DESCRIPTION
In new Chromaprint 1.4 (that was released 2016-12-03) type `ChromaprintContext` is no longer `void *`, but empty structure (see [commit 2132e19](https://bitbucket.org/acoustid/chromaprint/commits/2132e1966f240939d1cbb757f8ac7d9cbf53c824) from 2016-06-06). This breaks compilation of `libavformat/chromaprint.c`, because member `ctx` of `ChromaprintMuxContext` should be pointer. This simple change resolves the problem.