### PR TITLE
fixed for Floureon IP cameras

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,0 +1,1 @@
+2016-12-06: Fix assembly for NASM. See http://stackoverflow.com/questions/36854583/compiling-ffmpeg-for-kali-linux-2

--- a/libavformat/rtsp.c
+++ b/libavformat/rtsp.c
@@ -1566,7 +1566,6 @@ int ff_rtsp_make_setup_request(AVFormatContext *s, const char *host, int port,
                    reply->transports[0].lower_transport);
 	    av_log(s, AV_LOG_INFO, "Mask is %d\n", rt->lower_transport_mask);
 	    reply->transports[0].lower_transport = lower_transport;
-	    rt->lower_transport = lower_transport;
         }
 
         /* XXX: same protocol for all streams is required */

--- a/libavformat/rtsp.c
+++ b/libavformat/rtsp.c
@@ -1554,6 +1554,20 @@ int ff_rtsp_make_setup_request(AVFormatContext *s, const char *host, int port,
             goto fail;
         }
 
+        /* If the server responded with another lower transport mode
+         * than what we requested, complain but attempt to continue.
+         * Cheap IP cameras like Sricam SP005, for example, respond with
+         * `Transport: RTP/AVP` for a SETUP request of RTP/AVP/TCP
+	 * yet is sending over TCP anyway */
+        if (reply->transports[0].lower_transport != lower_transport) {
+            av_log(s, AV_LOG_ERROR, "Nonmatching transport in server reply\n");
+	    av_log(s, AV_LOG_INFO, "We asked for %d and got %d\n",
+                   lower_transport,
+                   reply->transports[0].lower_transport);
+	    reply->transports[0].lower_transport = lower_transport;
+	    rt->lower_transport = lower_transport;
+        }
+
         /* XXX: same protocol for all streams is required */
         if (i > 0) {
             if (reply->transports[0].lower_transport != rt->lower_transport ||
@@ -1564,16 +1578,6 @@ int ff_rtsp_make_setup_request(AVFormatContext *s, const char *host, int port,
         } else {
             rt->lower_transport = reply->transports[0].lower_transport;
             rt->transport = reply->transports[0].transport;
-        }
-
-        /* If the server responded with another lower transport mode
-         * than what we requested, complain but attempt to continue.
-         * Cheap IP cameras like Sricam SP005, for example, respond with
-         * `Transport: RTP/AVP` for a SETUP request of RTP/AVP/TCP */
-        if (reply->transports[0].lower_transport != lower_transport) {
-            av_log(s, AV_LOG_ERROR, "Nonmatching transport in server reply\n");
-	    reply->transports[0].lower_transport = lower_transport;
-	    rt->lower_transport = lower_transport;
         }
 
         switch(reply->transports[0].lower_transport) {

--- a/libavformat/rtsp.c
+++ b/libavformat/rtsp.c
@@ -1561,10 +1561,10 @@ int ff_rtsp_make_setup_request(AVFormatContext *s, const char *host, int port,
 	 * yet is sending over TCP anyway */
         if (reply->transports[0].lower_transport != lower_transport) {
             av_log(s, AV_LOG_ERROR, "Nonmatching transport in server reply\n");
-	    av_log(s, AV_LOG_INFO, "We asked for %d and got %d\n",
+	    av_log(s, AV_LOG_DEBUG, "We asked for %d and got %d\n",
                    lower_transport,
                    reply->transports[0].lower_transport);
-	    av_log(s, AV_LOG_INFO, "Mask is %d\n", rt->lower_transport_mask);
+	    av_log(s, AV_LOG_DEBUG, "Mask is %d\n", rt->lower_transport_mask);
 	    reply->transports[0].lower_transport = lower_transport;
         }
 

--- a/libavformat/rtsp.c
+++ b/libavformat/rtsp.c
@@ -1566,12 +1566,13 @@ int ff_rtsp_make_setup_request(AVFormatContext *s, const char *host, int port,
             rt->transport = reply->transports[0].transport;
         }
 
-        /* Fail if the server responded with another lower transport mode
-         * than what we requested. */
+        /* If the server responded with another lower transport mode
+         * than what we requested, complain but attempt to continue.
+         * Cheap IP cameras like Sricam SP005, for example, respond with
+         * `Transport: RTP/AVP` for a SETUP request of RTP/AVP/TCP */
         if (reply->transports[0].lower_transport != lower_transport) {
             av_log(s, AV_LOG_ERROR, "Nonmatching transport in server reply\n");
-            err = AVERROR_INVALIDDATA;
-            goto fail;
+	    reply->transports[0].lower_transport = lower_transport;
         }
 
         switch(reply->transports[0].lower_transport) {

--- a/libavformat/rtsp.c
+++ b/libavformat/rtsp.c
@@ -1564,6 +1564,7 @@ int ff_rtsp_make_setup_request(AVFormatContext *s, const char *host, int port,
 	    av_log(s, AV_LOG_INFO, "We asked for %d and got %d\n",
                    lower_transport,
                    reply->transports[0].lower_transport);
+	    av_log(s, AV_LOG_INFO, "Mask is %d\n", rt->lower_transport_mask);
 	    reply->transports[0].lower_transport = lower_transport;
 	    rt->lower_transport = lower_transport;
         }

--- a/libavformat/rtsp.c
+++ b/libavformat/rtsp.c
@@ -1573,6 +1573,7 @@ int ff_rtsp_make_setup_request(AVFormatContext *s, const char *host, int port,
         if (reply->transports[0].lower_transport != lower_transport) {
             av_log(s, AV_LOG_ERROR, "Nonmatching transport in server reply\n");
 	    reply->transports[0].lower_transport = lower_transport;
+	    rt->lower_transport = lower_transport;
         }
 
         switch(reply->transports[0].lower_transport) {


### PR DESCRIPTION
cheap rtsp-streaming ipcams use TCP but don't send proper header. this is a workaround.