### PR TITLE
Allow borderless playback windows

### DIFF
--- a/ffplay.c
+++ b/ffplay.c
@@ -321,6 +321,7 @@ static int subtitle_disable;
 static const char* wanted_stream_spec[AVMEDIA_TYPE_NB] = {0};
 static int seek_by_bytes = -1;
 static int display_disable;
+static int borderless;
 static int startup_volume = 100;
 static int show_status = 1;
 static int av_sync_type = AV_SYNC_AUDIO_MASTER;
@@ -1265,6 +1266,8 @@ static int video_open(VideoState *is)
             window_title = input_filename;
         if (is_full_screen)
             flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
+        if (borderless)
+            flags |= SDL_WINDOW_BORDERLESS;
         window = SDL_CreateWindow(window_title, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, w, h, flags);
         SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "linear");
         if (window) {
@@ -3513,6 +3516,7 @@ static const OptionDef options[] = {
     { "t", HAS_ARG, { .func_arg = opt_duration }, "play  \"duration\" seconds of audio/video", "duration" },
     { "bytes", OPT_INT | HAS_ARG, { &seek_by_bytes }, "seek by bytes 0=off 1=on -1=auto", "val" },
     { "nodisp", OPT_BOOL, { &display_disable }, "disable graphical display" },
+    { "noborder", OPT_BOOL, { &borderless }, "borderless display" },
     { "volume", OPT_INT | HAS_ARG, { &startup_volume}, "set startup volume 0=min 100=max", "volume" },
     { "f", HAS_ARG, { .func_arg = opt_format }, "force format", "fmt" },
     { "pix_fmt", HAS_ARG | OPT_EXPERT | OPT_VIDEO, { .func_arg = opt_frame_pix_fmt }, "set pixel format", "format" },


### PR DESCRIPTION
For a pure video tile effect, and enabling better integration of playback windows into other programs.  
It would improve the looks in many situations and [avoid ugly hacks like this](http://stackoverflow.com/q/31465630/315024).