### PR TITLE
Allow Data URI scheme

### DIFF
--- a/libavformat/hls.c
+++ b/libavformat/hls.c
@@ -617,8 +617,8 @@ static int open_url(AVFormatContext *s, AVIOContext **pb, const char *url,
     if (!proto_name)
         return AVERROR_INVALIDDATA;
 
-    // only http(s) & file are allowed
-    if (!av_strstart(proto_name, "http", NULL) && !av_strstart(proto_name, "file", NULL))
+    // only http(s) & file & data are allowed
+    if (!av_strstart(proto_name, "http", NULL) && !av_strstart(proto_name, "file", NULL) && !av_strstart(proto_name, "data", NULL))
         return AVERROR_INVALIDDATA;
     if (!strncmp(proto_name, url, strlen(proto_name)) && url[strlen(proto_name)] == ':')
         ;


### PR DESCRIPTION
Allow Data URI scheme
```
#EXT-X-KEY:METHOD=AES-128,URI="data:text/plain;charset=utf-8,abcdefg12345678",IV=0xffffffffffffffffffffffffffffffff
```
as video-js support the aes key wirte inline with data uri.
as ffurl_connect support data uri.
just allow it.