### PR TITLE
Fix static linking openssl library

### DIFF
--- a/configure
+++ b/configure
@@ -5942,6 +5942,7 @@ enabled omx               && { check_header OMX_Core.h || die "ERROR: OpenMAX IL
 enabled openssl           && { use_pkg_config openssl openssl/ssl.h OPENSSL_init_ssl ||
                                use_pkg_config openssl openssl/ssl.h SSL_library_init ||
                                check_lib openssl openssl/ssl.h SSL_library_init -lssl -lcrypto ||
+                               check_lib openssl openssl/ssl.h SSL_library_init -lssl -lcrypto -ldl ||
                                check_lib openssl openssl/ssl.h SSL_library_init -lssl32 -leay32 ||
                                check_lib openssl openssl/ssl.h SSL_library_init -lssl -lcrypto -lws2_32 -lgdi32 ||
                                die "ERROR: openssl not found"; }


### PR DESCRIPTION
Hi, if in system openssl builded only in static mode, need to add dl library to resolve dlopen undefined references. Tested on Raspbian.