### PR TITLE
Improved EXT-X-TARGETDURATION generation

### DIFF
--- a/libavformat/hlsenc.c
+++ b/libavformat/hlsenc.c
@@ -1038,8 +1038,8 @@ static int hls_window(AVFormatContext *s, int last)
         goto fail;
 
     for (en = hls->segments; en; en = en->next) {
-        if (target_duration <= en->duration)
-            target_duration = get_int_from_double(en->duration);
+        if (target_duration < en->duration)
+            target_duration = (int)round(en->duration);
     }
 
     hls->discontinuity_set = 0;


### PR DESCRIPTION
It improves EXT-X-TARGETDURATION when some chunk duration is bigger than requested -hls_time N

In the current implementation, it is ceiling the value (if float part is bigger than 0.001) but it should be rounded. Specification ​https://tools.ietf.org/html/draft-pantos-http-live-streaming-22#page-49 allows both implementation, but rounding is more precise and better matches user needs (especially having in mind that HLS segmenter could generate slightly longer than requested).

See conversation https://trac.ffmpeg.org/ticket/6533