### PR TITLE
CodeAi fixes: 1 Null Deref, 2 Dead Code, 2 Uninitialized Variables

### DIFF
--- a/libavcodec/h264_metadata_bsf.c
+++ b/libavcodec/h264_metadata_bsf.c
@@ -344,7 +344,6 @@ static int h264_metadata_filter(AVBSFContext *bsf, AVPacket *out)
         invalid_user_data:
             av_log(bsf, AV_LOG_ERROR, "Invalid user data: "
                    "must be \"UUID+string\".\n");
-            err = AVERROR(EINVAL);
         }
     }
 

--- a/libavcodec/indeo3.c
+++ b/libavcodec/indeo3.c
@@ -657,7 +657,6 @@ static int decode_cell(Indeo3DecodeContext *ctx, AVCodecContext *avctx,
             ref_block[x] = requant_tab[vq_index & 7][ref_block[x] & 127];
     }
 
-    error = IV3_NOERR;
 
     switch (mode) {
     case 0: /*------------------ MODES 0 & 1 (4x4 block processing) --------------------*/

--- a/libavfilter/af_afade.c
+++ b/libavfilter/af_afade.c
@@ -460,7 +460,7 @@ static int activate(AVFilterContext *ctx)
         return ff_filter_frame(outlink, in);
     }
 
-    if (ff_framequeue_queued_samples(&ctx->inputs[0]->fifo) > s->nb_samples) {
+    if (in && (ff_framequeue_queued_samples(&ctx->inputs[0]->fifo) > s->nb_samples)) {
         nb_samples = ff_framequeue_queued_samples(&ctx->inputs[0]->fifo) - s->nb_samples;
         if (nb_samples > 0) {
             ret = ff_inlink_consume_samples(ctx->inputs[0], nb_samples, nb_samples, &in);

--- a/libavformat/img2enc.c
+++ b/libavformat/img2enc.c
@@ -81,7 +81,7 @@ static int write_header(AVFormatContext *s)
 static int write_packet(AVFormatContext *s, AVPacket *pkt)
 {
     VideoMuxData *img = s->priv_data;
-    AVIOContext *pb[4];
+    AVIOContext *pb[4] = {0};
     char filename[1024];
     AVCodecParameters *par = s->streams[pkt->stream_index]->codecpar;
     const AVPixFmtDescriptor *desc = av_pix_fmt_desc_get(par->format);

--- a/libavutil/hash.c
+++ b/libavutil/hash.c
@@ -214,7 +214,7 @@ void av_hash_final_bin(struct AVHashContext *ctx, uint8_t *dst, int size)
 
 void av_hash_final_hex(struct AVHashContext *ctx, uint8_t *dst, int size)
 {
-    uint8_t buf[AV_HASH_MAX_SIZE];
+    uint8_t buf[AV_HASH_MAX_SIZE] = {0};
     unsigned rsize = av_hash_get_size(ctx), i;
 
     av_hash_final(ctx, buf);


### PR DESCRIPTION
CodeAI (www.mycode.ai) found 233 defects and fixed 205 in FFmpeg.  It wants to merge commits fixing 5 of these issues- 1 Null Pointer Dereference, 2 Dead Code, and 2 Uninitialized Variables.  A screenshot of the results as well as the Dockerfile used to build and run your project in CodeAI can be found here-
https://drive.google.com/open?id=13plMG_j6PyyVojsBiQQpYC1bkd4Tq6jn