### PR TITLE
Fix Markdown formatting in INSTALL

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,4 +1,4 @@
-#Installing FFmpeg:
+## Installing FFmpeg
 
 1. Type `./configure` to create the configuration. A list of configure
 options is printed by running `configure --help`.


### PR DESCRIPTION
Opted for an h2 because h1 seemed too big to me