### PR TITLE
fix transcoding  video  api  time_base error

### DIFF
--- a/doc/examples/transcoding.c
+++ b/doc/examples/transcoding.c
@@ -162,7 +162,7 @@ static int open_output_file(const char *filename)
                 else
                     enc_ctx->pix_fmt = dec_ctx->pix_fmt;
                 /* video time_base can be set to whatever is handy and supported by encoder */
-                enc_ctx->time_base = av_inv_q(dec_ctx->framerate);
+                enc_ctx->time_base = dec_ctx->time_base;
             } else {
                 enc_ctx->sample_rate = dec_ctx->sample_rate;
                 enc_ctx->channel_layout = dec_ctx->channel_layout;


### PR DESCRIPTION
i use the api  trascode mp4 file,time_base is erro, error causing video track playback of generated file