### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/tools/normalize.py
+++ b/tools/normalize.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python2
 
+from __future__ import print_function
 import sys, subprocess
 
 if len(sys.argv) > 2:
@@ -7,7 +8,7 @@ if len(sys.argv) > 2:
     encopt = sys.argv[2:-1]
     ofile  = sys.argv[-1]
 else:
-    print 'usage: %s <input> [encode_options] <output>' % sys.argv[0]
+    print('usage: %s <input> [encode_options] <output>' % sys.argv[0])
     sys.exit(1)
 
 analysis_cmd  = 'ffprobe -v error -of compact=p=0:nk=1 '
@@ -15,7 +16,7 @@ analysis_cmd += '-show_entries frame_tags=lavfi.r128.I -f lavfi '
 analysis_cmd += "amovie='%s',ebur128=metadata=1" % ifile
 try:
     probe_out = subprocess.check_output(analysis_cmd, shell=True)
-except subprocess.CalledProcessError, e:
+except subprocess.CalledProcessError as e:
     sys.exit(e.returncode)
 loudness = ref = -23
 for line in probe_out.splitlines():
@@ -24,10 +25,10 @@ for line in probe_out.splitlines():
         loudness = sline
 adjust = ref - float(loudness)
 if abs(adjust) < 0.0001:
-    print 'No normalization needed for ' + ifile
+    print('No normalization needed for ' + ifile)
 else:
-    print "Adjust %s by %.1fdB" % (ifile, adjust)
+    print("Adjust %s by %.1fdB" % (ifile, adjust))
     norm_cmd  = ['ffmpeg', '-i', ifile, '-af', 'volume=%fdB' % adjust]
     norm_cmd += encopt + [ofile]
-    print ' => %s' % ' '.join(norm_cmd)
+    print(' => %s' % ' '.join(norm_cmd))
     subprocess.call(norm_cmd)

--- a/tools/zmqshell.py
+++ b/tools/zmqshell.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python2
 
+from __future__ import print_function
 import sys, zmq, cmd
 
 class LavfiCmd(cmd.Cmd):
@@ -14,10 +15,10 @@ class LavfiCmd(cmd.Cmd):
     def onecmd(self, cmd):
         if cmd == 'EOF':
             sys.exit(0)
-        print 'Sending command:[%s]' % cmd
+        print('Sending command:[%s]' % cmd)
         self.requester.send(cmd)
         message = self.requester.recv()
-        print 'Received reply:[%s]' % message
+        print('Received reply:[%s]' % message)
 
 try:
     bind_address = sys.argv[1] if len(sys.argv) > 1 else "tcp://localhost:5555"


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.

Old style exceptions are syntax errors in Python 3 but new style exceptions work as expected in both Python 2 and Python 3.