### PR TITLE
avcodec/qsv: polling free synchronization

### DIFF
--- a/libavcodec/qsv_internal.h
+++ b/libavcodec/qsv_internal.h
@@ -111,4 +111,6 @@ int ff_qsv_init_session_frames(AVCodecContext *avctx, mfxSession *session,
 
 int ff_qsv_find_surface_idx(QSVFramesContext *ctx, QSVFrame *frame);
 
+void ff_qsv_handle_device_busy(mfxSession *session, mfxSyncPoint *sync, mfxStatus *ret, unsigned sleep);
+
 #endif /* AVCODEC_QSV_INTERNAL_H */

--- a/libavcodec/qsvdec.h
+++ b/libavcodec/qsvdec.h
@@ -70,6 +70,8 @@ typedef struct QSVContext {
 
     mfxExtBuffer **ext_buffers;
     int         nb_ext_buffers;
+
+    mfxSyncPoint last_dec_sync;
 } QSVContext;
 
 extern const AVCodecHWConfigInternal *ff_qsv_hw_configs[];

--- a/libavcodec/qsvenc.h
+++ b/libavcodec/qsvenc.h
@@ -185,6 +185,8 @@ typedef struct QSVEncContext {
     char *load_plugins;
     SetEncodeCtrlCB *set_encode_ctrl_cb;
     int forced_idr;
+
+    mfxSyncPoint last_enc_sync;
 } QSVEncContext;
 
 int ff_qsv_enc_init(AVCodecContext *avctx, QSVEncContext *q);


### PR DESCRIPTION
synchronization by sync point after DEVICE_BUSY

Fixes: CPU usage on AVC decode cases (18% -> 9%)