### PR TITLE
vf_drawtext.c: Fix compile for soft float mips

### DIFF
--- a/libavfilter/vf_drawtext.c
+++ b/libavfilter/vf_drawtext.c
@@ -1085,11 +1085,12 @@ static int func_eval_expr_int_format(AVFilterContext *ctx, AVBPrint *bp,
 
     feclearexcept(FE_ALL_EXCEPT);
     intval = res;
+#ifndef __mips_soft_float
     if ((ret = fetestexcept(FE_INVALID|FE_OVERFLOW|FE_UNDERFLOW))) {
         av_log(ctx, AV_LOG_ERROR, "Conversion of floating-point result to int failed. Control register: 0x%08x. Conversion result: %d\n", ret, intval);
         return AVERROR(EINVAL);
     }
-
+#endif
     if (argc == 3)
         av_strlcatf(fmt_str, sizeof(fmt_str), "0%u", positions);
     av_strlcatf(fmt_str, sizeof(fmt_str), "%c", argv[1][0]);


### PR DESCRIPTION
We have it as a patch since today: https://github.com/OpenVisionE2/openvision-development-platform/commit/015d066fd8b30acb65b5ebb2594381465830e3eb