### PR TITLE
fix: rtsp/transport parser should accept comma for parameters

### DIFF
--- a/libavformat/rtsp.c
+++ b/libavformat/rtsp.c
@@ -1001,11 +1001,9 @@ static void rtsp_parse_transport(AVFormatContext *s,
 
             while (*p != ';' && *p != '\0' && *p != ',')
                 p++;
-            if (*p == ';')
+            if (*p == ';' || *p == ',')
                 p++;
         }
-        if (*p == ',')
-            p++;
 
         reply->nb_transports++;
         if (reply->nb_transports >= RTSP_MAX_TRANSPORTS)


### PR DESCRIPTION
I needed this fix to make [Shinobi](https://github.com/ShinobiCCTV/Shinobi) works with recent chinese cameras.

We can read that FFmpeg is perfectly following the [RTSP specs](https://tools.ietf.org/html/rfc2326#page-58) : 
`Transports are comma separated, listed in order of preference. Parameters may be added to each transport, separated by a semicolon.`
But considering:
- VLC is working smart with not perfect cameras ;
- RTSP module in FFmpeg is not programmed to handle more than one transport ; 
=> this fix could be useful to anyone

I also think this fix might be improved by a better scan of parameters if ffmpeg wants to handle more than one transport.

Details: 
I'm using [Shinobi](https://github.com/ShinobiCCTV/Shinobi) to record cameras rtsp streams
For several cameras, cheap chinese ones, VLC is working to get stream but FFmpeg always crashes after it receives the RTSP transports parameters available.

`Transport: RTP/AVP;unicast;mode=PLAY;source=192.168.66.164;client_port=11658-11659;server_port=40000-40001,ssrc=FFFFCCCC`

After debugging the source code, it appears that FFmpeg is not considering that a comma `'` before `ssrc` is a correct separator and think it's a second transport.
Then it crashes because RTSP don't want to accept more than one transport.