### PR TITLE
Update ffplay.c

### DIFF
--- a/fftools/ffplay.c
+++ b/fftools/ffplay.c
@@ -1720,7 +1720,7 @@ display:
 
             av_bprint_init(&buf, 0, AV_BPRINT_SIZE_AUTOMATIC);
             av_bprintf(&buf,
-                      "%7.2f %s:%7.3f fd=%4d aq=%5dKB vq=%5dKB sq=%5dB f=%"PRId64"/%"PRId64"   \r",
+                      "%7.3f %s:%7.3f fd=%4d aq=%5dKB vq=%5dKB sq=%5dB f=%"PRId64"/%"PRId64"   \r",
                       get_master_clock(is),
                       (is->audio_st && is->video_st) ? "A-V" : (is->video_st ? "M-V" : (is->audio_st ? "M-A" : "   ")),
                       av_diff,


### PR DESCRIPTION
Add a 3 decimal place to the time stamp reported in the stats of the current frame. This increases `ffplay` reported precision to milliseconds (albeit artificially when such precision is not inherently present in the video).