### PR TITLE
avformat/hlsenc:Fix the duration becomes shorter after transcoding

### DIFF
--- a/libavformat/hlsenc.c
+++ b/libavformat/hlsenc.c
@@ -37,6 +37,7 @@
 #include "libavutil/mathematics.h"
 #include "libavutil/parseutils.h"
 #include "libavutil/avstring.h"
+#include "libavutil/bprint.h"
 #include "libavutil/intreadwrite.h"
 #include "libavutil/random_seed.h"
 #include "libavutil/opt.h"
@@ -2468,13 +2469,13 @@ static int hls_write_packet(AVFormatContext *s, AVPacket *pkt)
                                        * st->time_base.num / st->time_base.den;
             vs->dpp = (double)(pkt->duration) * st->time_base.num / st->time_base.den;
         } else {
-            if (pkt->duration) {
-                vs->duration += (double)(pkt->duration) * st->time_base.num / st->time_base.den;
-            } else {
-                av_log(s, AV_LOG_WARNING, "Stream %d packet with pts %" PRId64 " has duration 0. The segment duration may not be precise.\n",
-                       pkt->stream_index, pkt->pts);
-                vs->duration = (double)(pkt->pts - vs->end_pts) * st->time_base.num / st->time_base.den;
-            }
+//            if (pkt->duration) {
+//                vs->duration += (double)(pkt->duration) * st->time_base.num / st->time_base.den;
+//            } else {
+//                av_log(s, AV_LOG_WARNING, "Stream %d packet with pts %" PRId64 " has duration 0. The segment duration may not be precise.\n",
+//                       pkt->stream_index, pkt->pts);
+            vs->duration = (double)(pkt->pts - vs->end_pts) * st->time_base.num / st->time_base.den;
+//            }
         }
     }
 


### PR DESCRIPTION
Fix the problem of converting mp4 files to hls files, and the duration time of some videos becomes shorter after transcoding.

Source file information:
```
$ ffprobe input.mp4
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'input.mp4':
  Metadata:
    major_brand     : isom
    minor_version   : 512
    compatible_brands: isomiso2avc1mp41
    encoder         : Lavf58.29.100
  Duration: 00:34:04.87, start: 0.000000, bitrate: 204 kb/s
    Stream #0:0(und): Video: h264 (High) (avc1 / 0x31637661), yuv420p, 2160x1080, 72 kb/s, 15 fps, 120 tbr, 90k tbn, 2400k tbc (default)
    Metadata:
      handler_name    : VideoHandler
    Stream #0:1(und): Audio: aac (LC) (mp4a / 0x6134706D), 48000 Hz, mono, fltp, 125 kb/s (default)
    Metadata:
      handler_name    : SoundHandler
```

Before：
```
$ ffmpeg -probesize 50M -analyzeduration 120M -i input.mp4 -hide_banner -loglevel warning -max_muxing_queue_size 9999 -c:v copy -c:a copy -map 0 -hls_time 1 -hls_playlist_type vod  -hls_segment_filename v2/list%05d.ts -force_key_frames "expr:gte(t,n_forced*1)"  -f hls v2/list.m3u8
$ ffprobe v2/list.m3u8
[hls @ 0x7fb370810600] Skip ('#EXT-X-VERSION:3')
[hls @ 0x7fb370810600] Opening 'v2/list00000.ts' for reading
Input #0, hls, from 'v2/list.m3u8':
  Duration: 00:33:51.20, start: 1.533333, bitrate: 0 kb/s
  Program 0
    Metadata:
      variant_bitrate : 0
    Stream #0:0: Video: h264 (High) ([27][0][0][0] / 0x001B), yuv420p, 2160x1080, 120 tbr, 90k tbn, 2400k tbc
    Metadata:
      variant_bitrate : 0
    Stream #0:1: Audio: aac (LC) ([15][0][0][0] / 0x000F), 48000 Hz, mono, fltp
    Metadata:
      variant_bitrate : 0
```

After fixed：
```
$ ffmpeg -probesize 50M -analyzeduration 120M -i input.mp4 -hide_banner -loglevel warning -max_muxing_queue_size 9999 -c:v copy -c:a copy -map 0 -hls_time 1 -hls_playlist_type vod  -hls_segment_filename v2/list%05d.ts -force_key_frames "expr:gte(t,n_forced*1)"  -f hls v2/list.m3u8
$ ffprobe v2/list.m3u8
Input #0, hls,applehttp, from 'v2/list.m3u8':
  Duration: 00:34:04.81, start: 1.533333, bitrate: 0 kb/s
  Program 0
    Metadata:
      variant_bitrate : 0
    Stream #0:0: Video: h264 (High) ([27][0][0][0] / 0x001B), yuv420p, 2160x1080, 120 tbr, 90k tbn, 2400k tbc
    Stream #0:1: Audio: aac (LC) ([15][0][0][0] / 0x000F), 48000 Hz, mono, fltp, 127 kb/s
```

Test file address: https://github.com/lzle/bs/blob/master/ffmpeg/videos/input.mp4

