### PR TITLE
Update mjpegenc_common.c

### DIFF
--- a/libavcodec/mjpegenc_common.c
+++ b/libavcodec/mjpegenc_common.c
@@ -205,7 +205,7 @@ void ff_mjpeg_init_hvsample(AVCodecContext *avctx, int hsample[4], int vsample[4
         vsample[2] = hsample[2] =
         vsample[3] = hsample[3] = 1;
     } else if (avctx->pix_fmt == AV_PIX_FMT_YUV444P || avctx->pix_fmt == AV_PIX_FMT_YUVJ444P) {
-        vsample[0] = vsample[1] = vsample[2] = 2;
+        vsample[0] = vsample[1] = vsample[2] = 1;
         hsample[0] = hsample[1] = hsample[2] = 1;
     } else {
         vsample[0] = 2;


### PR DESCRIPTION
If the vsample[i] for YUV444 format  is set to 1, more hardware JPEG decoders can decode the bitstream encoded by FFMPEG successfully. This is because many hardware JPEG decoders only support 8x8 MCU for cost issue. Thus, I propose the change. Thank you!