### PR TITLE
Update configure file to fix a build failure with gcc-11 on Ubuntu 21.10

### DIFF
--- a/configure
+++ b/configure
@@ -5000,7 +5000,7 @@ elif enabled arm; then
         elif check_arm_arch 6ZK;      then echo armv6zk
         elif check_arm_arch 6T2;      then echo armv6t2
         elif check_arm_arch 7;        then echo armv7
-        elif check_arm_arch 7A  7_A;  then echo armv7-a
+        elif check_arm_arch 7A  7_A;  then echo armv7-a+fp
         elif check_arm_arch 7S;       then echo armv7-a
         elif check_arm_arch 7R  7_R;  then echo armv7-r
         elif check_arm_arch 7M  7_M;  then echo armv7-m


### PR DESCRIPTION
New gcc changed the way it exposes armhf build flags.
"the architecture now has to include the cpu features, see the man page, arM options"

example of build failure:
https://launchpad.net/ubuntu/+source/ffmpeg/7:4.4-6ubuntu1/+build/22070856

Note: this syntax was introduced in GCC 8 https://gcc.gnu.org/gcc-8/changes.html