### PR TITLE
libavdevice: fixed sdl handle packed yuv data

### DIFF
--- a/libavdevice/sdl2.c
+++ b/libavdevice/sdl2.c
@@ -298,13 +298,14 @@ static int sdl2_write_packet(AVFormatContext *s, AVPacket *pkt)
      * case SDL_PIXELFORMAT_ARGB2101010:
      */
     case SDL_PIXELFORMAT_IYUV:
-    case SDL_PIXELFORMAT_YUY2:
-    case SDL_PIXELFORMAT_UYVY:
         ret = SDL_UpdateYUVTexture(sdl->texture, NULL,
                                    data[0], linesize[0],
                                    data[1], linesize[1],
                                    data[2], linesize[2]);
         break;
+
+    case SDL_PIXELFORMAT_YUY2:
+    case SDL_PIXELFORMAT_UYVY:
     case SDL_PIXELFORMAT_RGB332:
     case SDL_PIXELFORMAT_RGB444:
     case SDL_PIXELFORMAT_RGB555:


### PR DESCRIPTION
# Descript
when use usb camera for input, and select sdl for output device,it will report "av_interleaved_write_frame(): Operation not permitted".SDL_UpdateYUVTexture only support planner data.when use pack data, it should use SDL_UpdateTexture.

# Reprouce Step
ffmpeg -f v4l2 -framerate 30 -video_size 640x480 -pix_fmt yuyv422 -i "/dev/video0"  -f sdl -s "640x480" -
it will report "av_interleaved_write_frame(): Operation not permitted" error.
