### PR TITLE
subtitles filter support shaping, some Khmer srt only work fine in sh…

### DIFF
--- a/libavfilter/vf_subtitles.c
+++ b/libavfilter/vf_subtitles.c
@@ -262,6 +262,10 @@ const AVFilter ff_vf_ass = {
 
 static const AVOption subtitles_options[] = {
     COMMON_OPTIONS
+    {"shaping", "set shaping engine", OFFSET(shaping), AV_OPT_TYPE_INT, { .i64 = -1 }, -1, 1, FLAGS, "shaping_mode"},
+        {"auto", NULL,                 0, AV_OPT_TYPE_CONST, {.i64 = -1},                  INT_MIN, INT_MAX, FLAGS, "shaping_mode"},
+        {"simple",  "simple shaping",  0, AV_OPT_TYPE_CONST, {.i64 = ASS_SHAPING_SIMPLE},  INT_MIN, INT_MAX, FLAGS, "shaping_mode"},
+        {"complex", "complex shaping", 0, AV_OPT_TYPE_CONST, {.i64 = ASS_SHAPING_COMPLEX}, INT_MIN, INT_MAX, FLAGS, "shaping_mode"},
     {"charenc",      "set input character encoding", OFFSET(charenc),      AV_OPT_TYPE_STRING, {.str = NULL}, 0, 0, FLAGS},
     {"stream_index", "set stream index",             OFFSET(stream_index), AV_OPT_TYPE_INT,    { .i64 = -1 }, -1,       INT_MAX,  FLAGS},
     {"si",           "set stream index",             OFFSET(stream_index), AV_OPT_TYPE_INT,    { .i64 = -1 }, -1,       INT_MAX,  FLAGS},


### PR DESCRIPTION
[WEWATCH-Slow Dancing.srt_to-km.zip](https://github.com/FFmpeg/FFmpeg/files/7514233/WEWATCH-Slow.Dancing.srt_to-km.zip)
![image](https://user-images.githubusercontent.com/758077/141149873-54993bb6-fade-42e6-87c8-207c93e9eb69.png)
Subtitles that do not work correctly are attached. See the red area in the picture for the display effect. After the code is modified, you can use the following command to resolve the problem:

`ffmpeg -i 1.mp4 -preset medium -vcodec libx264 -acodec libfdk_aac -movflags faststart -ss 0 -t 60 -filter_complex [0:v:0]subtitles='1.srt:shaping=complex:charenc=UTF-8:force_style=PlayResX=1280,PlayResY=720,Fontsize=45,Bold=0,Italic=0,BorderStyle=1,Outline=3,Spacing=0,Alignment=2,marginV=22'[v0] -map [v0] -map 0:a:0 -vb 2045k -ab 95k -profile:v high -pix_fmt yuv420p -y 1.mp4`
