### PR TITLE
libavcodec/aaccoder: Fix android-ndk-20 compilation

### DIFF
--- a/libavcodec/aaccoder.c
+++ b/libavcodec/aaccoder.c
@@ -799,7 +799,7 @@ static void search_for_ms(AACEncContext *s, ChannelElement *cpe)
 
                 for (sid_sf_boost = 0; sid_sf_boost < 4; sid_sf_boost++) {
                     float dist1 = 0.0f, dist2 = 0.0f;
-                    int B0 = 0, B1 = 0;
+                    int BSUM0 = 0, BSUM1 = 0;
                     int minidx;
                     int mididx, sididx;
                     int midcb, sidcb;
@@ -861,12 +861,12 @@ static void search_for_ms(AACEncContext *s, ChannelElement *cpe)
                                                     sididx,
                                                     sidcb,
                                                     mslambda / (minthr * bmax + FLT_MIN), INFINITY, &b4, NULL, 0);
-                        B0 += b1+b2;
-                        B1 += b3+b4;
+                        BSUM0 += b1+b2;
+                        BSUM1 += b3+b4;
                         dist1 -= b1+b2;
                         dist2 -= b3+b4;
                     }
-                    cpe->ms_mask[w*16+g] = dist2 <= dist1 && B1 < B0;
+                    cpe->ms_mask[w*16+g] = dist2 <= dist1 && BSUM1 < BSUM0;
                     if (cpe->ms_mask[w*16+g]) {
                         if (sce0->band_type[w*16+g] != NOISE_BT && sce1->band_type[w*16+g] != NOISE_BT) {
                             sce0->sf_idx[w*16+g] = mididx;
@@ -878,7 +878,7 @@ static void search_for_ms(AACEncContext *s, ChannelElement *cpe)
                             cpe->ms_mask[w*16+g] = 0;
                         }
                         break;
-                    } else if (B1 > B0) {
+                    } else if (BSUM1 > BSUM0) {
                         /* More boost won't fix this */
                         break;
                     }


### PR DESCRIPTION
Environment variable : 
export ANDROID_HOME=/home/xanadu/android
export ANDROID_ARM_32=${ANDROID_HOME}/arm_32
export NDK_HOME=${ANDROID_NDK_20}
export ANDROID_NDK=${NDK_HOME}
${NDK_HOME}/build/tools/make-standalone-toolchain.sh --platform=android-21 --arch=arm --install-dir=${ANDROID_ARM_32}
export TOOLCHAIN=${NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64
export SYS_PARENT=${NDK_HOME}/platforms/android-21
export PATH=${TOOLCHAIN}:${PATH}
export PATH=${TOOLCHAIN}/bin:${PATH}
export CXXFLAGS="-lstdc++"
export LDFLAGS='-static'
export ARCH=arm-linux-androideabi
export CC=armv7a-linux-androideabi21-clang
export CXX=armv7a-linux-androideabi21-clang++
export LD=arm-linux-androideabi-ld
export CFLAGS='-fPIC -march=armv7-a -mfloat-abi=softfp'
export SYSROOT=${SYS_PARENT}/arch-arm
export PATH=${ANDROID_ARM_32}:${PATH}
export PATH=${ANDROID_ARM_32}/bin:${PATH}
export ANDROID_INSTALL_PREFIX=${CXX_LIBRARY}/binary/common/arm_32
export PKG_CONFIG_PATH=${ANDROID_INSTALL_PREFIX}/lib/pkgconfig



Compile parameters:
./configure --prefix=${ANDROID_INSTALL_PREFIX} --disable-asm --disable-shared --enable-static --enable-small --disable-ffplay --disable-ffprobe --disable-doc --disable-symver --disable-libx264 --enable-gpl --enable-cross-compile --cross-prefix=arm-linux-androideabi- --arch=arm --cpu=armv7-a --target-os=linux --extra-cflags=-I${ANDROID_INSTALL_PREFIX}/include --extra-ldflags=-L${ANDROID_INSTALL_PREFIX}/lib --extra-libs="-ldl -static -lSDL2 -DBIONIC_IOCTL_NO_SIGNEDNESS_OVERLOAD"



Error prompt:
CC	libavcodec/aaccoder.o
libavcodec/aaccoder.c:802:25: error: expected identifier or '('
                    int B0 = 0, B1 = 0;
                        ^
/home/xanadu/android/arm_32/bin/../sysroot/usr/include/asm-generic/termbits.h:118:12: note: expanded from macro 'B0'
#define B0 0000000
           ^
libavcodec/aaccoder.c:864:28: error: expression is not assignable
                        B0 += b1+b2;
                        ~~ ^
libavcodec/aaccoder.c:865:25: error: use of undeclared identifier 'B1'
                        B1 += b3+b4;
                        ^
libavcodec/aaccoder.c:869:62: error: use of undeclared identifier 'B1'
                    cpe->ms_mask[w*16+g] = dist2 <= dist1 && B1 < B0;
                                                             ^
libavcodec/aaccoder.c:881:32: error: use of undeclared identifier 'B1'
                    } else if (B1 > B0) {
                               ^
5 errors generated.
make: *** [libavcodec/aaccoder.o] Error 1



Solution:
Modify variable names so that they do not conflict.