### PR TITLE
Fix for possible buffer overflow.

### DIFF
--- a/libavfilter/af_loudnorm.c
+++ b/libavfilter/af_loudnorm.c
@@ -206,10 +206,11 @@ static void detect_peak(LoudNormContext *s, int offset, int nb_samples, int chan
                     continue;
 
                 for (c = 0; c < channels; c++) {
-                    if (c == 0 || fabs(buf[index + c]) > max_peak)
-                        max_peak = fabs(buf[index + c]);
+		    int idx((index + c) < s->limiter_buf_size ? (index + c) : (index + c - s->limiter_buf_size));
+                    if (c == 0 || fabs(buf[idx]) > max_peak)
+                        max_peak = fabs(buf[idx]);
 
-                    s->prev_smp[c] = fabs(buf[(index + c) < s->limiter_buf_size ? (index + c) : (index + c - s->limiter_buf_size)]);
+                    s->prev_smp[c] = fabs(buf[idx]);
                 }
 
                 *peak_delta = n;

--- a/libavfilter/af_loudnorm.c
+++ b/libavfilter/af_loudnorm.c
@@ -206,7 +206,7 @@ static void detect_peak(LoudNormContext *s, int offset, int nb_samples, int chan
                     continue;
 
                 for (c = 0; c < channels; c++) {
-		    int idx((index + c) < s->limiter_buf_size ? (index + c) : (index + c - s->limiter_buf_size));
+                    int idx((index + c) < s->limiter_buf_size ? (index + c) : (index + c - s->limiter_buf_size));
                     if (c == 0 || fabs(buf[idx]) > max_peak)
                         max_peak = fabs(buf[idx]);
 


### PR DESCRIPTION
If it is true that the `(index + c)` can be larger than `s->limiter_buf_size`, then the overflow potential has to be handled in the previous two statements. I suggest to compute that index once and use it three times as shown in the patch. This is certainly the safest version.