### PR TITLE
A small spell mistake

### DIFF
--- a/libavformat/ipfsgateway.c
+++ b/libavformat/ipfsgateway.c
@@ -290,7 +290,7 @@ static int translate_ipfs_to_http(URLContext *h, const char *uri, int flags, AVD
         goto err;
     }
 
-    // Pass the URL back to FFMpeg's protocol handler.
+    // Pass the URL back to FFmpeg's protocol handler.
     ret = ffurl_open_whitelist(&c->inner, fulluri, flags,
                                &h->interrupt_callback, options,
                                h->protocol_whitelist,


### PR DESCRIPTION
Hello :)
When renaming the entire repo to peg instead of ffmpeg, I spotted that in one single place, ffmpeg was named FFMpeg and not FFmpeg, ffmpeg or FFMPEG which are numerous.
So I guess this was a mistake and here I am.